### PR TITLE
It should be possible to apply `SetSeverity` on `NotEmptyOrUnknown`

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 |-------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------|
 |![v](https://img.shields.io/badge/version-0.0.3-darkblue.svg?cacheSeconds=3600)|[Qowaiv.Validation.Abstractions](https://www.nuget.org/packages/Qowaiv.Validation.Abstractions/)      |
 |![v](https://img.shields.io/badge/version-0.0.3-blue.svg?cacheSeconds=3600)    |[Qowaiv.Validation.DataAnnotations](https://www.nuget.org/packages/Qowaiv.Validation.DataAnnotations/)|
-|![v](https://img.shields.io/badge/version-0.0.3-blue.svg?cacheSeconds=3600)    |[Qowaiv.Validation.Fluent](https://www.nuget.org/packages/Qowaiv.Validation.Fluent/)                  |
+|![v](https://img.shields.io/badge/version-0.0.4-blue.svg?cacheSeconds=3600)    |[Qowaiv.Validation.Fluent](https://www.nuget.org/packages/Qowaiv.Validation.Fluent/)                  |
 |![v](https://img.shields.io/badge/version-0.0.1-darkred.svg?cacheSeconds=3600) |[Qowaiv.Validation.TestTools](https://www.nuget.org/packages/Qowaiv.TestTools/)                       |
 
 # Qowaiv Validation

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,9 @@
 ﻿# Release Notes
 
+## Released 2020-05-29
+### Qowaiv.Validation.Fluent 0.0.4
+* Support `SetSeverity` and `WithMessage` on `NotEmptyOrUnknown` (#12) fix
+
 ## Released 2020-05-26
 ### Qowaiv.Validation.DataAnnotations 0.0.3
 * Made `OptionalAttribte` public (#9)
@@ -9,10 +13,6 @@
 ### Qowaiv.Validation.Fluent 0.0.3
 * Added `Required()` (#4)
 * Severity taken into account (#5) fix
-
-## Released 2019-11-25
-### Qowaiv.Validation.Abstractions 0.0.3
-* Added Support for Composed Actions.
 
 ## Released 2019-11-25
 ### Qowaiv.Validation.Abstractions 0.0.3

--- a/src/Qowaiv.Validation.Abstractions/Qowaiv.Validation.Abstractions.csproj
+++ b/src/Qowaiv.Validation.Abstractions/Qowaiv.Validation.Abstractions.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
  
   <ItemGroup>
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.6.1.17183">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.7.0.17535">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Qowaiv.Validation.Abstractions/ValidationMessage.cs
+++ b/src/Qowaiv.Validation.Abstractions/ValidationMessage.cs
@@ -11,9 +11,9 @@ namespace Qowaiv.Validation.Abstractions
         /// <summary>Creates a new instance of a <see cref="ValidationMessage"/>.</summary>
         public ValidationMessage() : this(ValidationSeverity.None, null, null) { }
 
-        internal ValidationMessage(ValidationSeverity serverity, string message, string propertyName)
+        internal ValidationMessage(ValidationSeverity severity, string message, string propertyName)
         {
-            Severity = serverity;
+            Severity = severity;
             Message = message;
             PropertyName = propertyName;
         }
@@ -117,9 +117,9 @@ namespace Qowaiv.Validation.Abstractions
         public static ValidationMessage Info(string message, string propertyName = null) => new ValidationMessage(ValidationSeverity.Info, message, propertyName);
 
         /// <summary>Creates a validation message.</summary>
-        public static IValidationMessage For(ValidationSeverity serverity, string message, string propertyName = null)
+        public static IValidationMessage For(ValidationSeverity severity, string message, string propertyName = null)
         {
-            switch (serverity)
+            switch (severity)
             {
                 case ValidationSeverity.None: return None;
                 case ValidationSeverity.Info: return Info(message, propertyName);

--- a/src/Qowaiv.Validation.DataAnnotations/Qowaiv.Validation.DataAnnotations.csproj
+++ b/src/Qowaiv.Validation.DataAnnotations/Qowaiv.Validation.DataAnnotations.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.6.0" />
     <PackageReference Include="Qowaiv" Version="5.1.1" />
     <PackageReference Include="Qowaiv" Version="5.1.1" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.6.1.17183">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.7.0.17535">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Qowaiv.Validation.DataAnnotations/ValidationMessage.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/ValidationMessage.cs
@@ -13,10 +13,10 @@ namespace Qowaiv.Validation.DataAnnotations
         /// <summary>Creates a new instance of a <see cref="ValidationMessage"/>.</summary>
         public ValidationMessage() : this(ValidationSeverity.None, null, null) { }
 
-        internal ValidationMessage(ValidationSeverity serverity, string message, string[] memberNames)
+        internal ValidationMessage(ValidationSeverity severity, string message, string[] memberNames)
             : base(message, memberNames)
         {
-            Severity = serverity;
+            Severity = severity;
         }
 
         /// <summary>Creates a new instance of <see cref="ValidationMessage"/>.</summary>
@@ -82,9 +82,9 @@ namespace Qowaiv.Validation.DataAnnotations
         }
 
         /// <summary>Creates a validation message.</summary>
-        public static IValidationMessage For(ValidationSeverity serverity, string message, string[] memberNames)
+        public static IValidationMessage For(ValidationSeverity severity, string message, string[] memberNames)
         {
-            switch (serverity)
+            switch (severity)
             {
                 case ValidationSeverity.None: return None;
                 case ValidationSeverity.Info: return Info(message, memberNames);

--- a/src/Qowaiv.Validation.Fluent/FluentValidation/UnknownValidation.cs
+++ b/src/Qowaiv.Validation.Fluent/FluentValidation/UnknownValidation.cs
@@ -1,4 +1,5 @@
-﻿using Qowaiv;
+﻿using FluentValidation.Validators;
+using Qowaiv;
 using Qowaiv.Validation.Fluent;
 
 namespace FluentValidation
@@ -32,8 +33,28 @@ namespace FluentValidation
         public static IRuleBuilderOptions<T, TProperty> NotEmptyOrUnknown<T, TProperty>(this IRuleBuilder<T, TProperty> ruleBuilder)
         {
             return Guard.NotNull(ruleBuilder, nameof(ruleBuilder))
-                .NotEmpty()
-                .NotUnknown();
+                .SetValidator(new NotEmptyOrUnknownValidator(default(TProperty)))
+                .WithMessage(m => QowaivValidationFluentMessages.NotEmptyOrUnknown);
+        }
+    }
+
+    /// <remarks>
+    /// To ensure that NotEmpty is validated equally for 
+    /// <see cref="UnknownValidation.NotEmptyOrUnknown{T, TProperty}(IRuleBuilder{T, TProperty})"/>
+    /// and
+    /// <see cref="UnknownValidation.NotUnknown{TModel, TProperty}(IRuleBuilder{TModel, TProperty})"/>
+    /// 
+    /// the <see cref="NotEmptyValidator"/> is overridden.
+    /// </remarks>
+    internal sealed class NotEmptyOrUnknownValidator : NotEmptyValidator
+    {
+        public NotEmptyOrUnknownValidator(object defaultValueForType)
+            : base(defaultValueForType) { }
+
+        protected override bool IsValid(PropertyValidatorContext context)
+        {
+            return base.IsValid(context)
+                && !Equals(Unknown.Value(context.PropertyValue.GetType()), context.PropertyValue);
         }
     }
 }

--- a/src/Qowaiv.Validation.Fluent/Qowaiv.Validation.Fluent.csproj
+++ b/src/Qowaiv.Validation.Fluent/Qowaiv.Validation.Fluent.csproj
@@ -5,14 +5,28 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>0.0.3</Version>
+    <Version>0.0.4</Version>
+    <PackageReleaseNotes>
+v.0.0.4
+- Support `SetSeverity` and `WithMessage` on `NotEmptyOrUnknown` (#12) fix
+
+v.0.0.3
+- Added `Required()` (#4)
+- Severity taken into account (#5) fix
+
+v.0.0.2
+- Added Guards for null
+
+v.0.0.1
+- Initial version
+    </PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="8.5.0" />
     <PackageReference Include="Qowaiv" Version="5.1.1" />
     <PackageReference Include="Qowaiv" Version="5.1.1" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.6.1.17183">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.7.0.17535">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Qowaiv.Validation.Fluent/QowaivValidationFluentMessages.Designer.cs
+++ b/src/Qowaiv.Validation.Fluent/QowaivValidationFluentMessages.Designer.cs
@@ -88,6 +88,15 @@ namespace Qowaiv.Validation.Fluent {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &apos;{PropertyName}&apos; must not be empty or unknown..
+        /// </summary>
+        internal static string NotEmptyOrUnknown {
+            get {
+                return ResourceManager.GetString("NotEmptyOrUnknown", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to &apos;{PropertyName}&apos; should not be in the future..
         /// </summary>
         internal static string NotInFuture {

--- a/src/Qowaiv.Validation.Fluent/QowaivValidationFluentMessages.nl.resx
+++ b/src/Qowaiv.Validation.Fluent/QowaivValidationFluentMessages.nl.resx
@@ -1,51 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
-    <xsd:element name="root" msdata:IsDataSet="true">
-      <xsd:complexType>
-        <xsd:choice maxOccurs="unbounded">
-          <xsd:element name="metadata">
-            <xsd:complexType>
-              <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" />
-              </xsd:sequence>
-              <xsd:attribute name="name" use="required" type="xsd:string" />
-              <xsd:attribute name="type" type="xsd:string" />
-              <xsd:attribute name="mimetype" type="xsd:string" />
-              <xsd:attribute ref="xml:space" />
-            </xsd:complexType>
-          </xsd:element>
-          <xsd:element name="assembly">
-            <xsd:complexType>
-              <xsd:attribute name="alias" type="xsd:string" />
-              <xsd:attribute name="name" type="xsd:string" />
-            </xsd:complexType>
-          </xsd:element>
-          <xsd:element name="data">
-            <xsd:complexType>
-              <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
-              </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
-              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
-              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
-              <xsd:attribute ref="xml:space" />
-            </xsd:complexType>
-          </xsd:element>
-          <xsd:element name="resheader">
-            <xsd:complexType>
-              <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-              </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" />
-            </xsd:complexType>
-          </xsd:element>
-        </xsd:choice>
-      </xsd:complexType>
-    </xsd:element>
-  </xsd:schema>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
   </resheader>
@@ -66,6 +20,9 @@
   </data>
   <data name="NoIPBasedEmailAddress" xml:space="preserve">
     <value>'{PropertyName}' heeft een IP-adres als domein.</value>
+  </data>
+  <data name="NotEmptyOrUnknown" xml:space="preserve">
+    <value>'{PropertyName}' mag niet leeg of onbekend zijn.</value>
   </data>
   <data name="NotInFuture" xml:space="preserve">
     <value>'{PropertyName}' mag niet in de toekomst liggen.</value>

--- a/src/Qowaiv.Validation.Fluent/QowaivValidationFluentMessages.resx
+++ b/src/Qowaiv.Validation.Fluent/QowaivValidationFluentMessages.resx
@@ -1,51 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
-    <xsd:element name="root" msdata:IsDataSet="true">
-      <xsd:complexType>
-        <xsd:choice maxOccurs="unbounded">
-          <xsd:element name="metadata">
-            <xsd:complexType>
-              <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" />
-              </xsd:sequence>
-              <xsd:attribute name="name" use="required" type="xsd:string" />
-              <xsd:attribute name="type" type="xsd:string" />
-              <xsd:attribute name="mimetype" type="xsd:string" />
-              <xsd:attribute ref="xml:space" />
-            </xsd:complexType>
-          </xsd:element>
-          <xsd:element name="assembly">
-            <xsd:complexType>
-              <xsd:attribute name="alias" type="xsd:string" />
-              <xsd:attribute name="name" type="xsd:string" />
-            </xsd:complexType>
-          </xsd:element>
-          <xsd:element name="data">
-            <xsd:complexType>
-              <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
-              </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
-              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
-              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
-              <xsd:attribute ref="xml:space" />
-            </xsd:complexType>
-          </xsd:element>
-          <xsd:element name="resheader">
-            <xsd:complexType>
-              <xsd:sequence>
-                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-              </xsd:sequence>
-              <xsd:attribute name="name" type="xsd:string" use="required" />
-            </xsd:complexType>
-          </xsd:element>
-        </xsd:choice>
-      </xsd:complexType>
-    </xsd:element>
-  </xsd:schema>
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
   </resheader>
@@ -66,6 +20,9 @@
   </data>
   <data name="NoIPBasedEmailAddress" xml:space="preserve">
     <value>'{PropertyName}' has a IP address based domain.</value>
+  </data>
+  <data name="NotEmptyOrUnknown" xml:space="preserve">
+    <value>'{PropertyName}' must not be empty or unknown.</value>
   </data>
   <data name="NotInFuture" xml:space="preserve">
     <value>'{PropertyName}' should not be in the future.</value>

--- a/src/Qowaiv.Validation.TestTools/FluentValidatorAssert.cs
+++ b/src/Qowaiv.Validation.TestTools/FluentValidatorAssert.cs
@@ -9,14 +9,22 @@ namespace Qowaiv.Validation.TestTools
     public static class FluentValidatorAssert
     {
         /// <summary>Asserts that the model is valid, throws if not.</summary>
-        [DebuggerStepThrough]
-        public static void IsValid<TValidator, TModel>(TModel model) where TValidator : FluentValidation.IValidator<TModel>
-            => IsValid(model, Activator.CreateInstance<TValidator>());
+       [DebuggerStepThrough]
+        public static void IsValid<TValidator, TModel>(TModel model, params IValidationMessage[] expected) where TValidator : FluentValidation.IValidator<TModel>
+            => IsValid(model, Activator.CreateInstance<TValidator>(), expected);
 
         /// <summary>Asserts that the model is valid, throws if not.</summary>
         [DebuggerStepThrough]
-        public static void IsValid<TModel>(TModel model, FluentValidation.IValidator<TModel> validator) 
-            => WithErrors(model, validator, new IValidationMessage[0]);
+        public static void IsValid<TModel>(TModel model, FluentValidation.IValidator<TModel> validator, params IValidationMessage[] expected)
+        {
+            if (validator is null)
+            {
+                throw new ArgumentNullException(nameof(validator));
+            }
+            var wrapper = new FluentValidator<TModel>(validator);
+            var result = wrapper.Validate(model);
+            ValidationMessageAssert.IsValid(result, expected);
+        }
 
         /// <summary>Asserts the model to be invalid with specific messages. Throws if not.</summary>
         [DebuggerStepThrough]

--- a/src/Qowaiv.Validation.TestTools/Qowaiv.Validation.TestTools.csproj
+++ b/src/Qowaiv.Validation.TestTools/Qowaiv.Validation.TestTools.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.6.1.17183">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.7.0.17535">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Qowaiv.Validation.Abstractions.UnitTests/Qowaiv.Validation.Abstractions.UnitTests.csproj
+++ b/test/Qowaiv.Validation.Abstractions.UnitTests/Qowaiv.Validation.Abstractions.UnitTests.csproj
@@ -17,7 +17,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="Qowaiv.TestTools" Version="3.1.0" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.6.1.17183">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.7.0.17535">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Qowaiv.Validation.DataAnnotations.UnitTests/Qowaiv.Validation.DataAnnotations.UnitTests.csproj
+++ b/test/Qowaiv.Validation.DataAnnotations.UnitTests/Qowaiv.Validation.DataAnnotations.UnitTests.csproj
@@ -17,7 +17,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="Qowaiv.TestTools" Version="3.1.0" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.6.1.17183">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.7.0.17535">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Qowaiv.Validation.Fluent.UnitTests/Models/UnknownModel.cs
+++ b/test/Qowaiv.Validation.Fluent.UnitTests/Models/UnknownModel.cs
@@ -1,16 +1,19 @@
 ﻿using FluentValidation;
+using Qowaiv.Globalization;
 
 namespace Qowaiv.Validation.Fluent.UnitTests.Models
 {
     public class UnknownModel
     {
         public EmailAddress Email { get; set; }
+        public Country Country { get; set; } = Country.NL;
     }
     public class UnknownModelValidator : AbstractValidator<UnknownModel>
     {
         public UnknownModelValidator()
         {
-            RuleFor(m => m.Email).NotEmptyOrUnknown();
+            RuleFor(m => m.Email).NotUnknown();
+            RuleFor(m => m.Country).NotEmptyOrUnknown();
         }
     }
 }

--- a/test/Qowaiv.Validation.Fluent.UnitTests/Models/UnknownWithServerityModel.cs
+++ b/test/Qowaiv.Validation.Fluent.UnitTests/Models/UnknownWithServerityModel.cs
@@ -1,0 +1,18 @@
+﻿using FluentValidation;
+
+namespace Qowaiv.Validation.Fluent.UnitTests.Models
+{
+    public class UnknownWithServerityModel
+    {
+        public EmailAddress Email { get; set; }
+    }
+    public class UnknownWithServerityModelValidator : AbstractValidator<UnknownWithServerityModel>
+    {
+        public UnknownWithServerityModelValidator()
+        {
+            RuleFor(m => m.Email)
+                .NotEmptyOrUnknown()
+                .WithSeverity(Severity.Warning);
+        }
+    }
+}

--- a/test/Qowaiv.Validation.Fluent.UnitTests/Models/UnknownWithSeverityModel.cs
+++ b/test/Qowaiv.Validation.Fluent.UnitTests/Models/UnknownWithSeverityModel.cs
@@ -2,13 +2,13 @@
 
 namespace Qowaiv.Validation.Fluent.UnitTests.Models
 {
-    public class UnknownWithServerityModel
+    public class UnknownWithSeverityModel
     {
         public EmailAddress Email { get; set; }
     }
-    public class UnknownWithServerityModelValidator : AbstractValidator<UnknownWithServerityModel>
+    public class UnknownWithSeverityModelValidator : AbstractValidator<UnknownWithSeverityModel>
     {
-        public UnknownWithServerityModelValidator()
+        public UnknownWithSeverityModelValidator()
         {
             RuleFor(m => m.Email)
                 .NotEmptyOrUnknown()

--- a/test/Qowaiv.Validation.Fluent.UnitTests/Qowaiv.Validation.Fluent.UnitTests.csproj
+++ b/test/Qowaiv.Validation.Fluent.UnitTests/Qowaiv.Validation.Fluent.UnitTests.csproj
@@ -13,7 +13,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.6.1.17183">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.7.0.17535">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Qowaiv.Validation.Fluent.UnitTests/Validators/UnknownValidatonTest.cs
+++ b/test/Qowaiv.Validation.Fluent.UnitTests/Validators/UnknownValidatonTest.cs
@@ -9,30 +9,57 @@ namespace Qowaiv.Validation.Fluent.UnitTests.Validators
     public class UnknownValidatonTest
     {
         [Test]
-        [SetCulture("en")]
-        public void Known_IsValid()
+        public void NotEmptyOrUnknown_is_valid_when_value()
+        {
+            var model = new UnknownModel { Country = Country.NL };
+            FluentValidatorAssert.IsValid<UnknownModelValidator, UnknownModel>(model);
+        }
+
+        [TestCase("'Country' must not be empty or unknown.", "en-GB")]
+        [TestCase("'Country' mag niet leeg of onbekend zijn.", "nl-BE")]
+        public void NotEmptyOrUnknown_with_error_when_empty(string message, CultureInfo culture)
+        {
+            using (new CultureInfoScope(culture))
+            {
+                var model = new UnknownModel { Country = Country.Empty };
+
+                FluentValidatorAssert.WithErrors<UnknownModelValidator, UnknownModel>(model,
+                    ValidationMessage.Error(message, "Country")
+                );
+            }
+        }
+
+        [TestCase("'Country' must not be empty or unknown.", "en-GB")]
+        [TestCase("'Country' mag niet leeg of onbekend zijn.", "nl-BE")]
+        public void NotEmptyOrUnknown_with_error_when_unknown(string message, CultureInfo culture)
+        {
+            using (new CultureInfoScope(culture))
+            {
+                var model = new UnknownModel { Country = Country.Unknown };
+
+                FluentValidatorAssert.WithErrors<UnknownModelValidator, UnknownModel>(model,
+                    ValidationMessage.Error(message, "Country")
+                );
+            }
+        }
+
+        [Test]
+        public void NoUnknown_is_valid_when_empty()
+        {
+            var model = new UnknownModel { Email = EmailAddress.Empty };
+            FluentValidatorAssert.IsValid<UnknownModelValidator, UnknownModel>(model);
+        }
+
+        [Test]
+        public void NoUnknown_is_valid_when_set()
         {
             var model = new UnknownModel { Email = EmailAddress.Parse("test@qowaiv.org") };
             FluentValidatorAssert.IsValid<UnknownModelValidator, UnknownModel>(model);
         }
 
-        [TestCase("'Email' must not be empty.", "en-GB")]
-        [TestCase("'Email' mag niet leeg zijn.", "nl-BE")]
-        public void Empty(string message, CultureInfo culture)
-        {
-            using (new CultureInfoScope(culture))
-            {
-                var model = new UnknownModel { Email = EmailAddress.Empty };
-
-                FluentValidatorAssert.WithErrors<UnknownModelValidator, UnknownModel>(model,
-                    ValidationMessage.Error(message, "Email")
-                );
-            }
-        }
-
         [TestCase("'Email' must not be unknown.", "en-GB")]
         [TestCase("'Email' mag niet onbekend zijn.", "nl-BE")]
-        public void Unknown(string message, CultureInfo culture)
+        public void NotUnknown_with_error_when_unknown(string message, CultureInfo culture)
         {
             using (new CultureInfoScope(culture))
             {
@@ -43,14 +70,24 @@ namespace Qowaiv.Validation.Fluent.UnitTests.Validators
                 );
             }
         }
-    
+
         [Test]
-        public void Validate_WithServerity_has_warning()
+        public void Validate_empty_WithServerity_has_warning()
+        {
+            var model = new UnknownWithServerityModel { Email = EmailAddress.Empty };
+
+            FluentValidatorAssert.IsValid<UnknownWithServerityModelValidator, UnknownWithServerityModel>(model,
+                ValidationMessage.Warn("'Email' must not be empty or unknown.", "Email")
+            );
+        }
+
+        [Test]
+        public void Validate_unknown_WithServerity_has_warning()
         {
             var model = new UnknownWithServerityModel { Email = EmailAddress.Unknown };
 
             FluentValidatorAssert.IsValid<UnknownWithServerityModelValidator, UnknownWithServerityModel>(model,
-                ValidationMessage.Warn("'Email' must not be unknown.", "Email")
+                ValidationMessage.Warn("'Email' must not be empty or unknown.", "Email")
             );
         }
 

--- a/test/Qowaiv.Validation.Fluent.UnitTests/Validators/UnknownValidatonTest.cs
+++ b/test/Qowaiv.Validation.Fluent.UnitTests/Validators/UnknownValidatonTest.cs
@@ -9,6 +9,7 @@ namespace Qowaiv.Validation.Fluent.UnitTests.Validators
     public class UnknownValidatonTest
     {
         [Test]
+        [SetCulture("en")]
         public void Known_IsValid()
         {
             var model = new UnknownModel { Email = EmailAddress.Parse("test@qowaiv.org") };
@@ -42,5 +43,16 @@ namespace Qowaiv.Validation.Fluent.UnitTests.Validators
                 );
             }
         }
+    
+        [Test]
+        public void Validate_WithServerity_has_warning()
+        {
+            var model = new UnknownWithServerityModel { Email = EmailAddress.Unknown };
+
+            FluentValidatorAssert.IsValid<UnknownWithServerityModelValidator, UnknownWithServerityModel>(model,
+                ValidationMessage.Warn("'Email' must not be unknown.", "Email")
+            );
+        }
+
     }
 }

--- a/test/Qowaiv.Validation.Fluent.UnitTests/Validators/UnknownValidatonTest.cs
+++ b/test/Qowaiv.Validation.Fluent.UnitTests/Validators/UnknownValidatonTest.cs
@@ -72,21 +72,21 @@ namespace Qowaiv.Validation.Fluent.UnitTests.Validators
         }
 
         [Test]
-        public void Validate_empty_WithServerity_has_warning()
+        public void Validate_empty_WithSeverity_has_warning()
         {
-            var model = new UnknownWithServerityModel { Email = EmailAddress.Empty };
+            var model = new UnknownWithSeverityModel { Email = EmailAddress.Empty };
 
-            FluentValidatorAssert.IsValid<UnknownWithServerityModelValidator, UnknownWithServerityModel>(model,
+            FluentValidatorAssert.IsValid<UnknownWithSeverityModelValidator, UnknownWithSeverityModel>(model,
                 ValidationMessage.Warn("'Email' must not be empty or unknown.", "Email")
             );
         }
 
         [Test]
-        public void Validate_unknown_WithServerity_has_warning()
+        public void Validate_unknown_WithSeverity_has_warning()
         {
-            var model = new UnknownWithServerityModel { Email = EmailAddress.Unknown };
+            var model = new UnknownWithSeverityModel { Email = EmailAddress.Unknown };
 
-            FluentValidatorAssert.IsValid<UnknownWithServerityModelValidator, UnknownWithServerityModel>(model,
+            FluentValidatorAssert.IsValid<UnknownWithSeverityModelValidator, UnknownWithSeverityModel>(model,
                 ValidationMessage.Warn("'Email' must not be empty or unknown.", "Email")
             );
         }


### PR DESCRIPTION
As described in #11 `SetServerity` (or `WithMessage`, or any other builder extension) only applied on the `NotUnknown` part. With this change, that is not longer the case. As a consequence of that, `NotEmptyOrUknown` not longer has a different message for `NotEmpty` and `NotUknown`.

If that is desired, you should use `.NotEmpty().NotUknown()`.