### PR TITLE
Introduction of (internal) inmutable message collection

### DIFF
--- a/src/Qowaiv.Validation.Abstractions/Internals/CollectionDebugView.cs
+++ b/src/Qowaiv.Validation.Abstractions/Internals/CollectionDebugView.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections;
+using System.Diagnostics;
+using System.Linq;
+
+namespace Qowaiv.Validation.Abstractions.Internals
+{
+    /// <summary>Allows the debugger to display collections.</summary>
+    internal class CollectionDebugView
+    {
+        /// <summary>Constructor.</summary>
+        public CollectionDebugView(IEnumerable enumeration) => Enumeration = enumeration;
+
+        /// <summary>The array that is shown by the debugger.</summary>
+        /// <remarks>
+        /// Every time the enumeration is shown in the debugger, a new array is created.
+        /// By doing this, it is always in sync with the current state of the enumeration.
+        /// </remarks>
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public object[] Items => Enumeration.Cast<object>().ToArray();
+
+        /// <summary>A reference to the enumeration to display.</summary>
+        private readonly IEnumerable Enumeration;
+    }
+}

--- a/src/Qowaiv.Validation.Abstractions/Internals/FixedMessages.cs
+++ b/src/Qowaiv.Validation.Abstractions/Internals/FixedMessages.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace Qowaiv.Validation.Abstractions.Internals
+{
+    [DebuggerDisplay("{DebuggerDisplay}"), DebuggerTypeProxy(typeof(CollectionDebugView))]
+    internal class FixedMessages : IReadOnlyList<IValidationMessage>
+    {
+        public static FixedMessages New(IEnumerable<IValidationMessage> messages)
+            => messages is FixedMessages @internal
+                ? @internal
+                : Empty.AddRange(messages);
+
+        public static readonly FixedMessages Empty = new FixedMessages();
+
+        public virtual int Count => 0;
+
+        public FixedMessages Add(IValidationMessage message)
+            => message.Severity > ValidationSeverity.None
+            ? new SomeFixedMessages(this, message)
+            : this;
+
+        public FixedMessages AddRange(IEnumerable<IValidationMessage> elements)
+        {
+            var next = this;
+            foreach(var element in elements)
+            {
+                next = next.Add(element);
+            }
+            return next;
+        }
+
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private string DebuggerDisplay => $"Count = {Count}";
+
+        public IValidationMessage this[int index] => this.Skip(index).FirstOrDefault() ?? throw new IndexOutOfRangeException();
+
+        public virtual IEnumerator<IValidationMessage> GetEnumerator() => Enumerable.Empty<IValidationMessage>().GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+}

--- a/src/Qowaiv.Validation.Abstractions/Internals/SomeFixedMessages.cs
+++ b/src/Qowaiv.Validation.Abstractions/Internals/SomeFixedMessages.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace Qowaiv.Validation.Abstractions.Internals
+{
+    internal class SomeFixedMessages : FixedMessages
+    {
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private readonly FixedMessages parent;
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private readonly IValidationMessage value;
+
+        public SomeFixedMessages(FixedMessages parent, IValidationMessage value)
+        {
+            this.parent = parent;
+            this.value = value;
+        }
+        
+        public override int Count => parent.Count+1;
+
+        public override IEnumerator<IValidationMessage> GetEnumerator() => Enumerate().Reverse().GetEnumerator();
+
+        private IEnumerable<IValidationMessage> Enumerate()
+        {
+            FixedMessages current = this;
+            while (current is SomeFixedMessages nonEmpty)
+            {
+                yield return nonEmpty.value;
+                current = nonEmpty.parent;
+            }
+        }
+    }
+}

--- a/src/Qowaiv.Validation.Abstractions/Result.cs
+++ b/src/Qowaiv.Validation.Abstractions/Result.cs
@@ -1,5 +1,5 @@
-﻿using System.Collections.Generic;
-using System.Collections.ObjectModel;
+﻿using Qowaiv.Validation.Abstractions.Internals;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Qowaiv.Validation.Abstractions
@@ -11,10 +11,9 @@ namespace Qowaiv.Validation.Abstractions
         /// <param name="messages">
         /// The messages related to the result.
         /// </param>
-        internal Result(IEnumerable<IValidationMessage> messages)
+        internal Result(FixedMessages messages)
         {
-            Guard.NotNull(messages, nameof(messages));
-            Messages = new ReadOnlyCollection<IValidationMessage>(messages.GetWithSeverity().ToList());
+            Messages = Guard.NotNull(messages, nameof(messages));
         }
 
         /// <summary>Gets the messages related to the result.</summary>
@@ -33,24 +32,30 @@ namespace Qowaiv.Validation.Abstractions
         public IEnumerable<IValidationMessage> Infos => Messages.GetInfos();
 
         /// <summary>Creates an OK <see cref="Result"/>.</summary>
-        public static Result OK => new Result(Enumerable.Empty<IValidationMessage>());
+        public static Result OK => new Result(FixedMessages.Empty);
 
         /// <summary>Creates a <see cref="Result{T}"/> for the data.</summary>
-        public static Result<T> For<T>(T data, IEnumerable<IValidationMessage> messages) => new Result<T>(data, messages);
+        public static Result<T> For<T>(T data, IEnumerable<IValidationMessage> messages)
+            => new Result<T>(data, FixedMessages.New(messages));
 
         /// <summary>Creates a <see cref="Result{T}"/> for the data.</summary>
-        public static Result<T> For<T>(T data, params IValidationMessage[] messages) => new Result<T>(data, messages);
+        public static Result<T> For<T>(T data, params IValidationMessage[] messages)
+            => new Result<T>(data, FixedMessages.New(messages));
 
         /// <summary>Creates a result with messages.</summary>
-        public static Result WithMessages(IEnumerable<IValidationMessage> messages) => new Result(messages);
+        public static Result WithMessages(IEnumerable<IValidationMessage> messages)
+            => new Result(FixedMessages.New(messages));
 
         /// <summary>Creates a result with messages.</summary>
-        public static Result WithMessages(params IValidationMessage[] messages) => new Result(messages);
+        public static Result WithMessages(params IValidationMessage[] messages) 
+            => new Result(FixedMessages.New(messages));
 
         /// <summary>Creates a result with messages.</summary>
-        public static Result<T> WithMessages<T>(IEnumerable<IValidationMessage> messages) => new Result<T>(default, messages);
+        public static Result<T> WithMessages<T>(IEnumerable<IValidationMessage> messages) 
+            => new Result<T>(default, FixedMessages.New(messages));
 
         /// <summary>Creates a result with messages.</summary>
-        public static Result<T> WithMessages<T>(params IValidationMessage[] messages) => new Result<T>(default, messages);
+        public static Result<T> WithMessages<T>(params IValidationMessage[] messages)
+            => new Result<T>(default, FixedMessages.New(messages));
     }
 }

--- a/src/Qowaiv.Validation.Abstractions/ResultActExtensions.cs
+++ b/src/Qowaiv.Validation.Abstractions/ResultActExtensions.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using System.Linq;
+﻿using Qowaiv.Validation.Abstractions.Internals;
+using System;
 using System.Threading.Tasks;
 
 namespace Qowaiv.Validation.Abstractions
@@ -34,14 +34,20 @@ namespace Qowaiv.Validation.Abstractions
             {
                 return Result.WithMessages<TOut>();
             }
-            if (!result.IsValid || ReferenceEquals(result.Value, null))
+            else if (!result.IsValid || ReferenceEquals(result.Value, null))
             {
                 return Result.WithMessages<TOut>(result.Messages);
             }
-            var messages = result.Messages.ToList();
-            var outcome = action(result.Value);
-            messages.AddRange(outcome.Messages);
-            return Result.For(outcome.IsValid ? outcome.Value : default, messages);
+            else
+            {
+                var messages = (FixedMessages)result.Messages;
+                var outcome = action(result.Value);
+
+                return Result.For(outcome.IsValid
+                    ? outcome.Value
+                    : default,
+                    messages.AddRange(outcome.Messages));
+            }
         }
 
         /// <summary>Invokes the action when <see cref="Result{TModel}"/> is valid.</summary>
@@ -71,15 +77,20 @@ namespace Qowaiv.Validation.Abstractions
             {
                 return Result.WithMessages<TOut>();
             }
-            if (!result.IsValid || ReferenceEquals(result.Value, null))
+            else if (!result.IsValid || ReferenceEquals(result.Value, null))
             {
                 return Result.WithMessages<TOut>(result.Messages);
             }
-
-            var messages = result.Messages.ToList();
-            var outcome = await action(result.Value).ConfigureAwait(false);
-            messages.AddRange(outcome.Messages);
-            return Result.For(outcome.IsValid ? outcome.Value : default, messages);
+            else
+            {
+                var messages = (FixedMessages)result.Messages;
+                var outcome = await action(result.Value).ConfigureAwait(false);
+                
+                return Result.For(outcome.IsValid
+                    ? outcome.Value 
+                    : default, 
+                    messages.AddRange(outcome.Messages));
+            }
         }
 
 
@@ -106,13 +117,12 @@ namespace Qowaiv.Validation.Abstractions
             {
                 return result;
             }
-            var messages = result.Messages.ToList();
-
-            var act = action(result.Value);
-
-            messages.AddRange(act.Messages);
-
-            return Result.For(result.Value, messages);
+            else
+            {
+                var messages = (FixedMessages)result.Messages;
+                var act = action(result.Value);
+                return Result.For(result.Value, messages.AddRange(act.Messages));
+            }
         }
 
         /// <summary>Invokes the action when <see cref="Result{TModel}"/> is valid.</summary>
@@ -134,15 +144,17 @@ namespace Qowaiv.Validation.Abstractions
             Guard.NotNull(action, nameof(action));
 
             var result = await promise.ConfigureAwait(false);
+
             if (!result.IsValid)
             {
                 return result;
             }
-
-            var messages = result.Messages.ToList();
-            var act = await action(result.Value).ConfigureAwait(false);
-            messages.AddRange(act.Messages);
-            return Result.For(result.Value, messages);
+            else
+            {
+                var messages = (FixedMessages)result.Messages;
+                var act = await action(result.Value).ConfigureAwait(false);
+                return Result.For(result.Value, messages.AddRange(act.Messages));
+            }
         }
     }
 }

--- a/src/Qowaiv.Validation.Abstractions/Result_TModel.cs
+++ b/src/Qowaiv.Validation.Abstractions/Result_TModel.cs
@@ -1,7 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using Qowaiv.Validation.Abstractions.Internals;
+using System;
 using System.Diagnostics;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace Qowaiv.Validation.Abstractions
@@ -16,7 +15,7 @@ namespace Qowaiv.Validation.Abstractions
         /// <param name="messages">
         /// The messages related to the result.
         /// </param>
-        internal Result(TModel data, IEnumerable<IValidationMessage> messages) : base(messages)
+        internal Result(TModel data, FixedMessages messages) : base(messages)
         {
             _value = IsValid ? data : default;
         }
@@ -60,10 +59,12 @@ namespace Qowaiv.Validation.Abstractions
                 return WithMessages<TOut>(Messages);
             }
 
-            var messages = Messages.ToList();
+            var messages = (FixedMessages)Messages;
             var outcome = action(Value);
-            messages.AddRange(outcome.Messages);
-            return For(outcome.IsValid ? outcome.Value : default, messages);
+            return For(outcome.IsValid 
+                ? outcome.Value 
+                : default,
+                messages.AddRange(outcome.Messages));
         }
 
         /// <summary>Invokes the action when <see cref="Result{TModel}"/> is valid.</summary>
@@ -85,10 +86,13 @@ namespace Qowaiv.Validation.Abstractions
                 return WithMessages<TOut>(Messages);
             }
 
-            var messages = Messages.ToList();
+            var messages = (FixedMessages)Messages;
             var outcome = await action(Value).ConfigureAwait(false);
-            messages.AddRange(outcome.Messages);
-            return For(outcome.IsValid ? outcome.Value : default, messages);
+            
+            return For(outcome.IsValid 
+                ? outcome.Value 
+                : default,
+                messages.AddRange(outcome.Messages));
         }
 
 
@@ -108,10 +112,9 @@ namespace Qowaiv.Validation.Abstractions
                 return WithMessages<TModel>(Messages);
             }
 
-            var messages = Messages.ToList();
+            var messages = (FixedMessages)Messages;
             var outcome = action(Value);
-            messages.AddRange(outcome.Messages);
-            return For(Value, messages);
+            return For(Value, messages.AddRange(outcome.Messages));
         }
 
         /// <summary>Invokes the action when <see cref="Result{TModel}"/> is valid.</summary>
@@ -130,10 +133,9 @@ namespace Qowaiv.Validation.Abstractions
                 return WithMessages<TModel>(Messages);
             }
 
-            var messages = Messages.ToList();
+            var messages = (FixedMessages)Messages;
             var outcome = await action(Value).ConfigureAwait(false);
-            messages.AddRange(outcome.Messages);
-            return For(Value, messages);
+            return For(Value, messages.AddRange(outcome.Messages));
         }
 
         /// <summary>Explicitly casts the <see cref="Result"/> to the type of the related model.</summary>

--- a/test/Qowaiv.Validation.Abstractions.UnitTests/ResultActTest.cs
+++ b/test/Qowaiv.Validation.Abstractions.UnitTests/ResultActTest.cs
@@ -210,12 +210,13 @@ namespace Qowaiv.Validation.Abstractions.UnitTests
 
     internal class TestModel
     {
+        public TestModel(int actions = 0) => Actions = actions;
+
         public int Actions { get; private set; }
 
         public Result<TestModel> ValidAction()
         {
-            Actions++;
-            return this;
+            return new TestModel(Actions +1);
         }
         public Result<TestModel> InvalidAction()
         {
@@ -225,8 +226,7 @@ namespace Qowaiv.Validation.Abstractions.UnitTests
 
         public Task<Result<TestModel>> ValidActionAsync()
         {
-            Actions++;
-            return Task.FromResult(Result.For(this));
+            return Task.FromResult(Result.For(new TestModel(Actions + 1)));
         }
         public Task<Result<TestModel>> InvalidActionAsync()
         {


### PR DESCRIPTION
As method chaining is to support functional scenario's, and by that potentially a lot of messages can be added to the result, copying the message collection on every act is expensive: using an inmutable collection that chains the deltas, is way more efficient.