### PR TITLE
Support FluentValidation 10.2.0

### DIFF
--- a/props/analytics.props
+++ b/props/analytics.props
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.17.0.26580">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.23.0.32424">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Qowaiv.Validation.Fluent/FluentValidation/NotEmptyOrUnknownValidator.cs
+++ b/src/Qowaiv.Validation.Fluent/FluentValidation/NotEmptyOrUnknownValidator.cs
@@ -5,20 +5,16 @@ namespace FluentValidation
 {
     /// <remarks>
     /// To ensure that NotEmpty is validated equally for
-    /// <see cref="UnknownValidation.NotEmptyOrUnknown{T, TProperty}(IRuleBuilder{T, TProperty})"/>
+    /// <see cref="UnknownValidation.NotEmptyOrUnknown{TModel, TProperty}(IRuleBuilder{TModel, TProperty})"/>
     /// and
     /// <see cref="UnknownValidation.NotUnknown{TModel, TProperty}(IRuleBuilder{TModel, TProperty})"/>
-    /// the <see cref="NotEmptyValidator"/> is overridden.
+    /// the <see cref="NotEmptyValidator{TModel, TProperty}"/> is overridden.
     /// </remarks>
-    internal sealed class NotEmptyOrUnknownValidator : NotEmptyValidator
+    internal sealed class NotEmptyOrUnknownValidator<TModel, TProperty> : NotEmptyValidator<TModel, TProperty>
     {
-        public NotEmptyOrUnknownValidator(object defaultValueForType)
-            : base(defaultValueForType) => Do.Nothing();
-
-        protected override bool IsValid(PropertyValidatorContext context)
-        {
-            return base.IsValid(context)
-                && !Equals(Unknown.Value(context.PropertyValue.GetType()), context.PropertyValue);
-        }
+        /// <inheritdoc />
+        public override bool IsValid(ValidationContext<TModel> context, TProperty value)
+            => base.IsValid(context, value)
+                && !Equals(Unknown.Value(typeof(TProperty)), value);
     }
 }

--- a/src/Qowaiv.Validation.Fluent/FluentValidation/PostalCodeValidation.cs
+++ b/src/Qowaiv.Validation.Fluent/FluentValidation/PostalCodeValidation.cs
@@ -20,10 +20,8 @@ namespace FluentValidation
         /// The county the postal code should be valid for.
         /// </param>
         public static IRuleBuilderOptions<TModel, PostalCode> ValidFor<TModel>(this IRuleBuilder<TModel, PostalCode> ruleBuilder, Country country)
-        {
-            return Guard.NotNull(ruleBuilder, nameof(ruleBuilder))
-                .ValidFor((model) => country);
-        }
+            => Guard.NotNull(ruleBuilder, nameof(ruleBuilder))
+            .ValidFor((model) => country);
 
         /// <summary>The postal code should be valid for the specified country.</summary>
         /// <typeparam name="TModel">
@@ -36,13 +34,11 @@ namespace FluentValidation
         /// The county the postal code should be valid for.
         /// </param>
         public static IRuleBuilderOptions<TModel, PostalCode> ValidFor<TModel>(this IRuleBuilder<TModel, PostalCode> ruleBuilder, Func<TModel, Country> country)
-        {
-            return Guard.NotNull(ruleBuilder, nameof(ruleBuilder))
+            => Guard.NotNull(ruleBuilder, nameof(ruleBuilder))
                 .Must((model, postalCode, context) => IsValidFor(postalCode, country(model), context))
                 .WithMessage(m => QowaivValidationFluentMessages.PostalCodeValidForCountry);
-        }
 
-        private static bool IsValidFor(PostalCode postalCode, Country country, PropertyValidatorContext context)
+        private static bool IsValidFor<TModel>(PostalCode postalCode, Country country, ValidationContext<TModel> context)
         {
             if (country.IsEmptyOrUnknown()
                 || postalCode.IsEmptyOrUnknown()

--- a/src/Qowaiv.Validation.Fluent/FluentValidation/UnknownValidation.cs
+++ b/src/Qowaiv.Validation.Fluent/FluentValidation/UnknownValidation.cs
@@ -26,14 +26,12 @@ namespace FluentValidation
         }
 
         /// <summary>Defines a 'not empty' and a 'not unkmown' validator on the current rule builder.</summary>
-        /// <typeparam name="T">Type of object being validated.</typeparam>
+        /// <typeparam name="TModel">Type of object being validated.</typeparam>
         /// <typeparam name="TProperty">Type of property being validated.</typeparam>
         /// <param name="ruleBuilder">The rule builder on which the validator should be defined.</param>
-        public static IRuleBuilderOptions<T, TProperty> NotEmptyOrUnknown<T, TProperty>(this IRuleBuilder<T, TProperty> ruleBuilder)
-        {
-            return Guard.NotNull(ruleBuilder, nameof(ruleBuilder))
-                .SetValidator(new NotEmptyOrUnknownValidator(default(TProperty)))
+        public static IRuleBuilderOptions<TModel, TProperty> NotEmptyOrUnknown<TModel, TProperty>(this IRuleBuilder<TModel, TProperty> ruleBuilder)
+            => Guard.NotNull(ruleBuilder, nameof(ruleBuilder))
+                .SetValidator(new NotEmptyOrUnknownValidator<TModel, TProperty>())
                 .WithMessage(m => QowaivValidationFluentMessages.NotEmptyOrUnknown);
-        }
     }
 }

--- a/src/Qowaiv.Validation.Fluent/Qowaiv.Validation.Fluent.csproj
+++ b/src/Qowaiv.Validation.Fluent/Qowaiv.Validation.Fluent.csproj
@@ -4,8 +4,10 @@
   
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>0.0.6</Version>
+    <Version>0.0.7</Version>
     <PackageReleaseNotes>
+v0.0.7
+- Update to FluentValidation v10.2.0.
 v0.0.6
 - ModelValidator instead of FluentModelValidator (#18)
 - Drop FluentValidator (#19)
@@ -29,7 +31,7 @@ v0.0.1
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentValidation" Version="9.0.1" />
+    <PackageReference Include="FluentValidation" Version="10.2.0" />
     <PackageReference Include="Qowaiv" Version="5.1.1" />
   </ItemGroup>
 

--- a/src/Qowaiv.Validation.Fluent/ValidationMessage.cs
+++ b/src/Qowaiv.Validation.Fluent/ValidationMessage.cs
@@ -35,13 +35,16 @@ namespace Qowaiv.Validation.Fluent
             => Guard.NotNull(messages, nameof(messages)).Select(message => For(message));
 
         /// <summary>Creates an error message.</summary>
-        public static ValidationMessage Error(string message, string propertyName) => new ValidationMessage(propertyName, message) { Severity = Severity.Error };
+        public static ValidationMessage Error(string message, string propertyName)
+            => new ValidationMessage(propertyName, message) { Severity = Severity.Error };
 
         /// <summary>Creates a warning message.</summary>
-        public static ValidationMessage Warn(string message, string propertyName) => new ValidationMessage(propertyName, message) { Severity = Severity.Warning };
+        public static ValidationMessage Warn(string message, string propertyName)
+            => new ValidationMessage(propertyName, message) { Severity = Severity.Warning };
 
         /// <summary>Creates an info message.</summary>
-        public static ValidationMessage Info(string message, string propertyName) => new ValidationMessage(propertyName, message) { Severity = Severity.Info };
+        public static ValidationMessage Info(string message, string propertyName)
+            => new ValidationMessage(propertyName, message) { Severity = Severity.Info };
 
         /// <summary>Gets a <see cref="ValidationMessage"/> based on a <see cref="ValidationFailure"/>.</summary>
         public static ValidationMessage For(ValidationFailure failure)
@@ -52,7 +55,6 @@ namespace Qowaiv.Validation.Fluent
                 AttemptedValue = failure.AttemptedValue,
                 CustomState = failure.CustomState,
                 ErrorCode = failure.ErrorCode,
-                FormattedMessageArguments = failure.FormattedMessageArguments,
                 FormattedMessagePlaceholderValues = failure.FormattedMessagePlaceholderValues,
                 Severity = failure.Severity,
             };

--- a/src/Qowaiv.Validation.TestTools/ValidationMessageAssert.cs
+++ b/src/Qowaiv.Validation.TestTools/ValidationMessageAssert.cs
@@ -1,4 +1,7 @@
-﻿using Qowaiv.Validation.Abstractions;
+﻿#pragma warning disable S4055 // Literals should not be passed as localized parameters
+// Lightweight assertion.
+
+using Qowaiv.Validation.Abstractions;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/test/Qowaiv.Validation.Abstractions.UnitTests/Qowaiv.Validation.Abstractions.UnitTests.csproj
+++ b/test/Qowaiv.Validation.Abstractions.UnitTests/Qowaiv.Validation.Abstractions.UnitTests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="nunit" Version="3.13.1" />
+    <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="Qowaiv.TestTools" Version="3.1.0" />
@@ -15,7 +15,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="Qowaiv.TestTools" Version="3.1.0" />
   </ItemGroup>
 

--- a/test/Qowaiv.Validation.DataAnnotations.UnitTests/Qowaiv.Validation.DataAnnotations.UnitTests.csproj
+++ b/test/Qowaiv.Validation.DataAnnotations.UnitTests/Qowaiv.Validation.DataAnnotations.UnitTests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="nunit" Version="3.13.1" />
+    <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="Qowaiv.TestTools" Version="3.1.0" />
@@ -15,7 +15,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="Qowaiv.TestTools" Version="3.1.0" />
   </ItemGroup>
 

--- a/test/Qowaiv.Validation.Fluent.UnitTests/Qowaiv.Validation.Fluent.UnitTests.csproj
+++ b/test/Qowaiv.Validation.Fluent.UnitTests/Qowaiv.Validation.Fluent.UnitTests.csproj
@@ -7,12 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="nunit" Version="3.13.1" />
+    <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Qowaiv.Validation.Messages.UnitTests/Qowaiv.Validation.Messages.UnitTests.csproj
+++ b/test/Qowaiv.Validation.Messages.UnitTests/Qowaiv.Validation.Messages.UnitTests.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="nunit" Version="3.13.1" />
+    <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
FluentValidation.NET launched version 10, with some [breaking changes](https://docs.fluentvalidation.net/en/latest/upgrading-to-10.html).

This PR adapts these changes.