### PR TITLE
Extend Result<T> with Act() on context

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@
 
 | version                                                                       | package                                                                                              |
 |-------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------|
-|![v](https://img.shields.io/badge/version-0.0.4-darkblue.svg?cacheSeconds=3600)|[Qowaiv.Validation.Abstractions](https://www.nuget.org/packages/Qowaiv.Validation.Abstractions/)      |
+|![v](https://img.shields.io/badge/version-0.0.5-darkblue.svg?cacheSeconds=3600)|[Qowaiv.Validation.Abstractions](https://www.nuget.org/packages/Qowaiv.Validation.Abstractions/)      |
 |![v](https://img.shields.io/badge/version-0.0.3-blue.svg?cacheSeconds=3600)    |[Qowaiv.Validation.DataAnnotations](https://www.nuget.org/packages/Qowaiv.Validation.DataAnnotations/)|
 |![v](https://img.shields.io/badge/version-0.0.6-blue.svg?cacheSeconds=3600)    |[Qowaiv.Validation.Fluent](https://www.nuget.org/packages/Qowaiv.Validation.Fluent/)                  |
-|![v](https://img.shields.io/badge/version-0.0.1-blue.svg?cacheSeconds=3600)    |[Qowaiv.Validation.Messages](https://www.nuget.org/packages/Qowaiv.Validation.Messages/)              |
+|![v](https://img.shields.io/badge/version-0.0.2-blue.svg?cacheSeconds=3600)    |[Qowaiv.Validation.Messages](https://www.nuget.org/packages/Qowaiv.Validation.Messages/)              |
 |![v](https://img.shields.io/badge/version-0.0.2-darkred.svg?cacheSeconds=3600) |[Qowaiv.Validation.TestTools](https://www.nuget.org/packages/Qowaiv.TestTools/)                       |
 
 # Qowaiv Validation
@@ -122,7 +122,7 @@ Result<Context> context = NewContext()
     .Act(c => Service.GetValue(), (c, value) => c.Value = value)
     .Act(c => Service.GetOther(), (c, other) => c.Value = other);
 ```
-Or, with an immutable context:
+Or, with a (shared) immutable context:
 ``` C#
 Result<Context> context = NewContext()
     .Act(c => Service.GetValue(), (c, value) => /* return Context */ c.Update(value))

--- a/README.md
+++ b/README.md
@@ -116,7 +116,12 @@ if (result.Isvalid)
 }
 ```
 
-
+It is also possible to have multiple acts that update a shared context:
+``` C#
+Result<Context> context = NewContext()
+    .Act(c => Service.GetValue(), (c, value) => c.Value = value)
+    .Act(c => Service.GetOther(), (c, other) => c.Value = other);
+```
 
 ### IValidationMessage
 The common ground of validation messages.

--- a/README.md
+++ b/README.md
@@ -122,6 +122,12 @@ Result<Context> context = NewContext()
     .Act(c => Service.GetValue(), (c, value) => c.Value = value)
     .Act(c => Service.GetOther(), (c, other) => c.Value = other);
 ```
+Or, with an immutable context:
+``` C#
+Result<Context> context = NewContext()
+    .Act(c => Service.GetValue(), (c, value) => /* return Context */ c.Update(value))
+    .Act(c => Service.GetOther(), (c, other) => /* return Context */ c.Update(other));
+```
 
 ### IValidationMessage
 The common ground of validation messages.

--- a/src/Qowaiv.Validation.Abstractions/Extensions/TaskExtensions.cs
+++ b/src/Qowaiv.Validation.Abstractions/Extensions/TaskExtensions.cs
@@ -1,0 +1,12 @@
+﻿using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+
+namespace Qowaiv.Validation.Abstractions
+{
+    internal static class TaskExtensions
+    {
+        /// <summary>Continue the awaitable <see cref="Task"/> on any context, not necessarily the captured one.</summary>
+        public static ConfiguredTaskAwaitable<T> ContinueOnAnyContext<T>(this Task<T> task)
+            => task.ConfigureAwait(continueOnCapturedContext: false);
+    }
+}

--- a/src/Qowaiv.Validation.Abstractions/Qowaiv.Validation.Abstractions.csproj
+++ b/src/Qowaiv.Validation.Abstractions/Qowaiv.Validation.Abstractions.csproj
@@ -4,10 +4,13 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>0.0.4</Version>
+    <Version>0.0.5</Version>
     <PackageReleaseNotes>
-  v0.0.4
-  - Act() methods have pipe notation alternatives.
+      v0.0.5
+      - Act() methods on context #29
+      - AsTask() method for Result&lt;T&gt; #28
+      v0.0.4
+      - Act() methods have pipe notation alternatives.
     </PackageReleaseNotes>
   </PropertyGroup>
  

--- a/src/Qowaiv.Validation.Abstractions/ResultActExtensions.cs
+++ b/src/Qowaiv.Validation.Abstractions/ResultActExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
 namespace Qowaiv.Validation.Abstractions
@@ -241,9 +240,5 @@ namespace Qowaiv.Validation.Abstractions
                 ? Result.WithMessages<TModel>()
                 : await result.ActAsync(action, update).ContinueOnAnyContext();
         }
-
-        /// <summary>Continue the awaitable <see cref="Task"/> on any context, not necessarily the captured one.</summary>
-        internal static ConfiguredTaskAwaitable<T> ContinueOnAnyContext<T>(this Task<T> task)
-            => task.ConfigureAwait(continueOnCapturedContext: false);
     }
 }

--- a/src/Qowaiv.Validation.Abstractions/ResultActExtensions.cs
+++ b/src/Qowaiv.Validation.Abstractions/ResultActExtensions.cs
@@ -113,11 +113,11 @@ namespace Qowaiv.Validation.Abstractions
         /// <param name="promise">
         /// The promise of the result.
         /// </param>
-        /// <param name="update">
-        /// The update to apply on a successfully invoked action.
-        /// </param>
         /// <param name="action">
         /// The action to invoke.
+        /// </param>
+        /// <param name="update">
+        /// The update to apply on a successfully invoked action.
         /// </param>
         /// <typeparam name="TModel">
         /// The type of input result.
@@ -146,11 +146,11 @@ namespace Qowaiv.Validation.Abstractions
         /// <param name="promise">
         /// The promise of the result.
         /// </param>
-        /// <param name="update">
-        /// The update to apply on a successfully invoked action.
-        /// </param>
         /// <param name="action">
         /// The action to invoke.
+        /// </param>
+        /// <param name="update">
+        /// The update to apply on a successfully invoked action.
         /// </param>
         /// <typeparam name="TModel">
         /// The type of input result.
@@ -179,11 +179,11 @@ namespace Qowaiv.Validation.Abstractions
         /// <param name="promise">
         /// The promise of the result.
         /// </param>
-        /// <param name="update">
-        /// The update to apply on a successfully invoked action.
-        /// </param>
         /// <param name="action">
         /// The action to invoke.
+        /// </param>
+        /// <param name="update">
+        /// The update to apply on a successfully invoked action.
         /// </param>
         /// <typeparam name="TModel">
         /// The type of input result.
@@ -212,11 +212,11 @@ namespace Qowaiv.Validation.Abstractions
         /// <param name="promise">
         /// The promise of the result.
         /// </param>
-        /// <param name="update">
-        /// The update to apply on a successfully invoked action.
-        /// </param>
         /// <param name="action">
         /// The action to invoke.
+        /// </param>
+        /// <param name="update">
+        /// The update to apply on a successfully invoked action.
         /// </param>
         /// <typeparam name="TModel">
         /// The type of input result.

--- a/src/Qowaiv.Validation.Abstractions/ResultActExtensions.cs
+++ b/src/Qowaiv.Validation.Abstractions/ResultActExtensions.cs
@@ -85,6 +85,72 @@ namespace Qowaiv.Validation.Abstractions
         /// <param name="promise">
         /// The promise of the result.
         /// </param>
+        /// <param name="update">
+        /// The update to apply on a successfully invoked action.
+        /// </param>
+        /// <param name="action">
+        /// The action to invoke.
+        /// </param>
+        /// <typeparam name="TModel">
+        /// The type of input result.
+        /// </typeparam>
+        /// <typeparam name="TOut">
+        /// The type of the new result value.
+        /// </typeparam>
+        /// <returns>
+        /// The updated model with the merged messages.
+        /// </returns>
+        public static async Task<Result<TModel>> ActAsync<TModel, TOut>(
+            this Task<Result<TModel>> promise,
+            Func<TModel, Task<Result<TOut>>> action,
+            Action<TModel, TOut> update)
+        {
+            _ = Guard.NotNull(promise, nameof(promise));
+            Guard.NotNull(action, nameof(action));
+
+            var result = await promise.ConfigureAwait(false);
+            return result is null
+                ? Result.WithMessages<TModel>()
+                : await result.ActAsync(action, update).ConfigureAwait(false) ;
+        }
+
+        /// <summary>Invokes the action when <see cref="Result{TModel}"/> is valid.</summary>
+        /// <param name="promise">
+        /// The promise of the result.
+        /// </param>
+        /// <param name="update">
+        /// The update to apply on a successfully invoked action.
+        /// </param>
+        /// <param name="action">
+        /// The action to invoke.
+        /// </param>
+        /// <typeparam name="TModel">
+        /// The type of input result.
+        /// </typeparam>
+        /// <typeparam name="TOut">
+        /// The type of the new result value.
+        /// </typeparam>
+        /// <returns>
+        /// The updated model with the merged messages.
+        /// </returns>
+        public static async Task<Result<TModel>> ActAsync<TModel, TOut>(
+            this Task<Result<TModel>> promise,
+            Func<TModel, Task<Result<TOut>>> action,
+            Func<TModel, TOut, TModel> update)
+        {
+            _ = Guard.NotNull(promise, nameof(promise));
+            Guard.NotNull(action, nameof(action));
+
+            var result = await promise.ConfigureAwait(false);
+            return result is null
+                ? Result.WithMessages<TModel>()
+                : await result.ActAsync(action, update).ConfigureAwait(false);
+        }
+
+        /// <summary>Invokes the action when <see cref="Result{TModel}"/> is valid.</summary>
+        /// <param name="promise">
+        /// The promise of the result.
+        /// </param>
         /// <param name="action">
         /// The action to invoke.
         /// </param>

--- a/src/Qowaiv.Validation.Abstractions/Result_TModel.cs
+++ b/src/Qowaiv.Validation.Abstractions/Result_TModel.cs
@@ -157,7 +157,7 @@ namespace Qowaiv.Validation.Abstractions
             }
 
             var messages = (FixedMessages)Messages;
-            var outcome = await action(Value).ConfigureAwait(false);
+            var outcome = await action(Value).ContinueOnAnyContext();
 
             return For(outcome.IsValid
                 ? outcome.Value
@@ -182,7 +182,7 @@ namespace Qowaiv.Validation.Abstractions
             }
 
             var messages = (FixedMessages)Messages;
-            var outcome = await action(Value).ConfigureAwait(false);
+            var outcome = await action(Value).ContinueOnAnyContext();
             return For(Value, messages.AddRange(outcome.Messages));
         }
 
@@ -227,7 +227,7 @@ namespace Qowaiv.Validation.Abstractions
         {
             Guard.NotNull(update, nameof(update));
 
-            var resolved = await ActAsync(action).ConfigureAwait(false);
+            var resolved = await ActAsync(action).ContinueOnAnyContext();
             return resolved.IsValid
                 ? For(update(Value, resolved.Value), resolved.Messages)
                 : For(Value, resolved.Messages);

--- a/src/Qowaiv.Validation.Abstractions/Result_TModel.cs
+++ b/src/Qowaiv.Validation.Abstractions/Result_TModel.cs
@@ -55,7 +55,7 @@ namespace Qowaiv.Validation.Abstractions
         {
             Guard.NotNull(action, nameof(action));
 
-            if (IsNullValueOrInvalid(this))
+            if (InvalidOrNull())
             {
                 return WithMessages<TOut>(Messages);
             }
@@ -79,7 +79,7 @@ namespace Qowaiv.Validation.Abstractions
         {
             Guard.NotNull(action, nameof(action));
 
-            if (IsNullValueOrInvalid(this))
+            if (InvalidOrNull())
             {
                 return WithMessages<TModel>(Messages);
             }
@@ -149,7 +149,7 @@ namespace Qowaiv.Validation.Abstractions
         {
             _ = Guard.NotNull(action, nameof(action));
 
-            if (IsNullValueOrInvalid(this))
+            if (InvalidOrNull())
             {
                 return WithMessages<TOut>(Messages);
             }
@@ -174,7 +174,7 @@ namespace Qowaiv.Validation.Abstractions
         {
             _ = Guard.NotNull(action, nameof(action));
 
-            if (IsNullValueOrInvalid(this))
+            if (InvalidOrNull())
             {
                 return WithMessages<TModel>(Messages);
             }
@@ -261,7 +261,6 @@ namespace Qowaiv.Validation.Abstractions
         public static Result<TModel> operator |(Result<TModel> result, Func<TModel, Result> action)
             => Guard.NotNull(result, nameof(result)).Act(action);
 
-        private static bool IsNullValueOrInvalid<T>(Result<T> result)
-           => !result.IsValid || ReferenceEquals(null, result._value);
+        private bool InvalidOrNull() => !IsValid || ReferenceEquals(null, _value);
     }
 }

--- a/src/Qowaiv.Validation.Abstractions/Result_TModel.cs
+++ b/src/Qowaiv.Validation.Abstractions/Result_TModel.cs
@@ -38,9 +38,6 @@ namespace Qowaiv.Validation.Abstractions
             }
         }
 
-        /// <summary>Has no value (including being invalid).</summary>
-        internal bool HasNoValue() => _value is null || !IsValid;
-
         /// <summary>Gets the <see cref="Result{TModel}"/> as a <see cref="Task{TResult}"/>.</summary>
         public Task<Result<TModel>> AsTask() => Task.FromResult(this);
 
@@ -110,7 +107,8 @@ namespace Qowaiv.Validation.Abstractions
         public Result<TModel> Act<TOut>(Func<TModel, Result<TOut>> action, Action<TModel, TOut> update)
             => Act(action, (model, result) =>
             {
-                Guard.NotNull(update, nameof(update)).Invoke(model, result);
+                Guard.NotNull(update, nameof(update));
+                if (model is { }) { update.Invoke(model, result); }
                 return model;
             });
 
@@ -133,8 +131,8 @@ namespace Qowaiv.Validation.Abstractions
 
             var resolved = Act(action);
             return resolved.IsValid
-                ? For(update(Value, resolved.Value), resolved.Messages)
-                : For(Value, resolved.Messages);
+                ? For(update(_value, resolved.Value), resolved.Messages)
+                : For(_value, resolved.Messages);
         }
 
         /// <summary>Invokes the action when <see cref="Result{TModel}"/> is valid.</summary>
@@ -204,7 +202,8 @@ namespace Qowaiv.Validation.Abstractions
             Action<TModel, TOut> update)
             => ActAsync(action, (model, result) =>
             {
-                Guard.NotNull(update, nameof(update)).Invoke(model, result);
+                Guard.NotNull(update, nameof(update));
+                if (model is { }) { update.Invoke(model, result); }
                 return model;
             });
 
@@ -229,8 +228,8 @@ namespace Qowaiv.Validation.Abstractions
 
             var resolved = await ActAsync(action).ContinueOnAnyContext();
             return resolved.IsValid
-                ? For(update(Value, resolved.Value), resolved.Messages)
-                : For(Value, resolved.Messages);
+                ? For(update(_value, resolved.Value), resolved.Messages)
+                : For(_value, resolved.Messages);
         }
 
         /// <summary>Explicitly casts the <see cref="Result"/> to the type of the related model.</summary>

--- a/src/Qowaiv.Validation.Abstractions/Result_TModel.cs
+++ b/src/Qowaiv.Validation.Abstractions/Result_TModel.cs
@@ -261,7 +261,7 @@ namespace Qowaiv.Validation.Abstractions
         public static Result<TModel> operator |(Result<TModel> result, Func<TModel, Result> action)
             => Guard.NotNull(result, nameof(result)).Act(action);
 
-        internal static bool IsNullValueOrInvalid<T>(Result<T> result)
+        private static bool IsNullValueOrInvalid<T>(Result<T> result)
            => !result.IsValid || ReferenceEquals(null, result._value);
     }
 }

--- a/src/Qowaiv.Validation.Messages/Qowaiv.Validation.Messages.csproj
+++ b/src/Qowaiv.Validation.Messages/Qowaiv.Validation.Messages.csproj
@@ -4,12 +4,14 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>0.0.1</Version>
+    <Version>0.0.2</Version>
     <PackageReleaseNotes>
-v0.0.1
-- AccessDenied (#22)
-- ConcurrencyIssue (#22)
-- EntityNotFound (#22)
+      v0.0.2
+      - AccessDenied (#30)
+      v0.0.1
+      - AccessDenied (#22)
+      - ConcurrencyIssue (#22)
+      - EntityNotFound (#22)
     </PackageReleaseNotes>
   </PropertyGroup>
 

--- a/test/Qowaiv.Validation.Abstractions.UnitTests/Result_Act_Immutable_Context_specs.cs
+++ b/test/Qowaiv.Validation.Abstractions.UnitTests/Result_Act_Immutable_Context_specs.cs
@@ -3,7 +3,7 @@ using Qowaiv.Validation.Abstractions;
 using Qowaiv.Validation.TestTools;
 using System.Threading.Tasks;
 
-namespace Result_Act_Inmutable_Context_specs
+namespace Result_Act_Immutable_Context_specs
 {
     public class Task_Null
     {

--- a/test/Qowaiv.Validation.Abstractions.UnitTests/Result_Act_Inmutable_Context_specs.cs
+++ b/test/Qowaiv.Validation.Abstractions.UnitTests/Result_Act_Inmutable_Context_specs.cs
@@ -1,0 +1,185 @@
+﻿using NUnit.Framework;
+using Qowaiv.Validation.Abstractions;
+using Qowaiv.Validation.TestTools;
+using System.Threading.Tasks;
+
+namespace Result_Act_Inmutable_Context_specs
+{
+    public class Task_Null
+    {
+        [Test]
+        public async Task ActAsync_with_sync_is_never_triggered()
+        {
+            var result = await Context.NullTask.ActAsync(Actions.Failure, Context.Update);
+            ValidationMessageAssert.IsValid(result);
+        }
+
+        [Test]
+        public async Task ActAsync_with_async_is_never_triggered()
+        {
+            var result = await Context.NullTask.ActAsync(Actions.FailureAsync, Context.Update);
+            ValidationMessageAssert.IsValid(result);
+        }
+    }
+
+    public class Task_Null_Context
+    {
+        [Test]
+        public async Task ActAsync_with_sync_is_never_triggered()
+        {
+            var result = await Context.Null.AsTask().ActAsync(Actions.Failure, Context.Update);
+            ValidationMessageAssert.IsValid(result);
+        }
+
+        [Test]
+        public async Task ActAsync_with_async_is_never_triggered()
+        {
+            var result = await Context.Null.AsTask().ActAsync(Actions.FailureAsync, Context.Update);
+            ValidationMessageAssert.IsValid(result);
+        }
+    }
+
+    public class Null_Model
+    {
+        [Test]
+        public void Act_is_never_triggered()
+        {
+            var result = Context.Null.Act(Actions.Failure, Context.Update);
+            ValidationMessageAssert.IsValid(result);
+        }
+
+        [Test]
+        public async Task ActAsync_is_never_triggered()
+        {
+            var result = await Context.Null.ActAsync(Actions.FailureAsync, Context.Update);
+            ValidationMessageAssert.IsValid(result);
+        }
+    }
+
+    public class Valid_Model
+    {
+        [Test]
+        public void Act_on_success_is_executed_and_result_stays_valid()
+        {
+            var result = Context.Valid.Act(Actions.Success, Context.Update);
+            ValidationMessageAssert.IsValid(result);
+            Assert.That(result.Value.Updated, Is.True);
+        }
+
+        [Test]
+        public void Act_on_failing_makes_result_invalid()
+        {
+            var result = Context.Valid.Act(Actions.Failure, Context.Update);
+            ValidationMessageAssert.WithErrors(result, ValidationMessage.Error("Failure"));
+        }
+
+        [Test]
+        public async Task ActAsync_on_success_is_executed_and_result_stays_valid()
+        {
+            var result = await Context.Valid.ActAsync(Actions.SuccessAsync, Context.Update);
+            ValidationMessageAssert.IsValid(result);
+            Assert.That(result.Value.Updated, Is.True);
+        }
+
+        [Test]
+        public async Task ActAsync_on_failing_makes_result_invalid()
+        {
+            var result = await Context.Valid.ActAsync(Actions.FailureAsync, Context.Update);
+            ValidationMessageAssert.WithErrors(result, ValidationMessage.Error("FailureAsync"));
+        }
+    }
+
+    public class Task_Valid_Model
+    {
+        [Test]
+        public async Task ActAsync_on_sync_success_is_executed_and_result_stays_valid()
+        {
+            var result = await Context.Valid.AsTask().ActAsync(Actions.Success, Context.Update);
+            ValidationMessageAssert.IsValid(result);
+            Assert.That(result.Value.Updated, Is.True);
+        }
+
+        [Test]
+        public async Task ActAsync_on_async_success_is_executed_and_result_stays_valid()
+        {
+            var result = await Context.Valid.AsTask().ActAsync(Actions.SuccessAsync, Context.Update);
+            ValidationMessageAssert.IsValid(result);
+            Assert.That(result.Value.Updated, Is.True);
+        }
+
+        [Test]
+        public async Task ActAsync_on_sync_failing_makes_result_invalid()
+        {
+            var result = await Context.Valid.AsTask().ActAsync(Actions.Failure, Context.Update);
+            ValidationMessageAssert.WithErrors(result, ValidationMessage.Error("Failure"));
+        }
+
+        [Test]
+        public async Task ActAsync_on_async_failing_makes_result_invalid()
+        {
+            var result = await Context.Valid.AsTask().ActAsync(Actions.FailureAsync, Context.Update);
+            ValidationMessageAssert.WithErrors(result, ValidationMessage.Error("FailureAsync"));
+        }
+    }
+
+    public class Invalid_Model
+    {
+        [Test]
+        public void Act_is_never_triggered()
+        {
+            var result = Context.Invalid.Act(Actions.Failure, Context.Update);
+            ValidationMessageAssert.WithErrors(result, ValidationMessage.Error("InvalidContext"));
+        }
+
+        [Test]
+        public async Task ActAsync_is_never_triggered()
+        {
+            var result = await Context.Invalid.ActAsync(Actions.FailureAsync, Context.Update);
+            ValidationMessageAssert.WithErrors(result, ValidationMessage.Error("InvalidContext"));
+        }
+    }
+
+    public class Task_Invalid_Model
+    {
+        [Test]
+        public async Task ActAsync_with_sync_is_never_triggered()
+        {
+            var result = await Context.Invalid.AsTask().ActAsync(Actions.Failure, Context.Update);
+            ValidationMessageAssert.WithErrors(result, ValidationMessage.Error("InvalidContext"));
+        }
+
+        [Test]
+        public async Task ActAsync_with_async_is_never_triggered()
+        {
+            var result = await Context.Invalid.AsTask().ActAsync(Actions.FailureAsync, Context.Update);
+            ValidationMessageAssert.WithErrors(result, ValidationMessage.Error("InvalidContext"));
+        }
+    }
+
+    internal record Context(string Value)
+    {
+        public static Task<Result<Context>> NullTask => Task.FromResult<Result<Context>>(null);
+        public static Result<Context> Null => Result.For<Context>(null);
+        public static Result<Context> Valid => Result.For(new Context((string)null));
+        public static Result<Context> Invalid => Result.WithMessages<Context>(ValidationMessage.Error("InvalidContext"));
+
+        public bool Updated => Value is { };
+
+        public static Context Update(Context context, string value) => new(value);
+    }
+
+    internal static class Actions
+    {
+        public static Result<string> Success(Context context)
+            => Result.For(nameof(Success));
+
+        public static Task<Result<string>> SuccessAsync(Context context)
+            => Result.For(nameof(SuccessAsync)).AsTask();
+        
+        public static Result<string> Failure(Context context) 
+            => Result.WithMessages<string>(ValidationMessage.Error(nameof(Failure)));
+
+        public static Task<Result<string>> FailureAsync(Context context)
+            => Result.WithMessages<string>(ValidationMessage.Error(nameof(FailureAsync))).AsTask();
+    }
+}

--- a/test/Qowaiv.Validation.Abstractions.UnitTests/Result_Act_Mutable_Context_specs.cs
+++ b/test/Qowaiv.Validation.Abstractions.UnitTests/Result_Act_Mutable_Context_specs.cs
@@ -1,0 +1,186 @@
+﻿using NUnit.Framework;
+using Qowaiv.Validation.Abstractions;
+using Qowaiv.Validation.TestTools;
+using System.Threading.Tasks;
+
+namespace Result_Act_Mutable_Context_specs
+{
+    public class Task_Null
+    {
+        [Test]
+        public async Task ActAsync_with_sync_is_never_triggered()
+        {
+            var result = await Context.NullTask.ActAsync(Actions.Failure, Context.Update);
+            ValidationMessageAssert.IsValid(result);
+        }
+
+        [Test]
+        public async Task ActAsync_with_async_is_never_triggered()
+        {
+            var result = await Context.NullTask.ActAsync(Actions.FailureAsync, Context.Update);
+            ValidationMessageAssert.IsValid(result);
+        }
+    }
+
+    public class Task_Null_Context
+    {
+        [Test]
+        public async Task ActAsync_with_sync_is_never_triggered()
+        {
+            var result = await Context.Null.AsTask().ActAsync(Actions.Failure, Context.Update);
+            ValidationMessageAssert.IsValid(result);
+        }
+
+        [Test]
+        public async Task ActAsync_with_async_is_never_triggered()
+        {
+            var result = await Context.Null.AsTask().ActAsync(Actions.FailureAsync, Context.Update);
+            ValidationMessageAssert.IsValid(result);
+        }
+    }
+
+    public class Null_Model
+    {
+        [Test]
+        public void Act_is_never_triggered()
+        {
+            var result = Context.Null.Act(Actions.Failure, Context.Update);
+            ValidationMessageAssert.IsValid(result);
+        }
+
+        [Test]
+        public async Task ActAsync_is_never_triggered()
+        {
+            var result = await Context.Null.ActAsync(Actions.FailureAsync, Context.Update);
+            ValidationMessageAssert.IsValid(result);
+        }
+    }
+
+    public class Valid_Model
+    {
+        [Test]
+        public void Act_on_success_is_executed_and_result_stays_valid()
+        {
+            var result = Context.Valid.Act(Actions.Success, Context.Update);
+            ValidationMessageAssert.IsValid(result);
+            Assert.That(result.Value.Updated, Is.True);
+        }
+
+        [Test]
+        public void Act_on_failing_makes_result_invalid()
+        {
+            var result = Context.Valid.Act(Actions.Failure, Context.Update);
+            ValidationMessageAssert.WithErrors(result, ValidationMessage.Error("Failure"));
+        }
+
+        [Test]
+        public async Task ActAsync_on_success_is_executed_and_result_stays_valid()
+        {
+            var result = await Context.Valid.ActAsync(Actions.SuccessAsync, Context.Update);
+            ValidationMessageAssert.IsValid(result);
+            Assert.That(result.Value.Updated, Is.True);
+        }
+
+        [Test]
+        public async Task ActAsync_on_failing_makes_result_invalid()
+        {
+            var result = await Context.Valid.ActAsync(Actions.FailureAsync, Context.Update);
+            ValidationMessageAssert.WithErrors(result, ValidationMessage.Error("FailureAsync"));
+        }
+    }
+
+    public class Task_Valid_Model
+    {
+        [Test]
+        public async Task ActAsync_on_sync_success_is_executed_and_result_stays_valid()
+        {
+            var result = await Context.Valid.AsTask().ActAsync(Actions.Success, Context.Update);
+            ValidationMessageAssert.IsValid(result);
+            Assert.That(result.Value.Updated, Is.True);
+        }
+
+        [Test]
+        public async Task ActAsync_on_async_success_is_executed_and_result_stays_valid()
+        {
+            var result = await Context.Valid.AsTask().ActAsync(Actions.SuccessAsync, Context.Update);
+            ValidationMessageAssert.IsValid(result);
+            Assert.That(result.Value.Updated, Is.True);
+        }
+
+        [Test]
+        public async Task ActAsync_on_sync_failing_makes_result_invalid()
+        {
+            var result = await Context.Valid.AsTask().ActAsync(Actions.Failure, Context.Update);
+            ValidationMessageAssert.WithErrors(result, ValidationMessage.Error("Failure"));
+        }
+
+        [Test]
+        public async Task ActAsync_on_async_failing_makes_result_invalid()
+        {
+            var result = await Context.Valid.AsTask().ActAsync(Actions.FailureAsync, Context.Update);
+            ValidationMessageAssert.WithErrors(result, ValidationMessage.Error("FailureAsync"));
+        }
+    }
+
+    public class Invalid_Model
+    {
+        [Test]
+        public void Act_is_never_triggered()
+        {
+            var result = Context.Invalid.Act(Actions.Failure, Context.Update);
+            ValidationMessageAssert.WithErrors(result, ValidationMessage.Error("InvalidContext"));
+        }
+
+        [Test]
+        public async Task ActAsync_is_never_triggered()
+        {
+            var result = await Context.Invalid.ActAsync(Actions.FailureAsync, Context.Update);
+            ValidationMessageAssert.WithErrors(result, ValidationMessage.Error("InvalidContext"));
+        }
+    }
+
+    public class Task_Invalid_Model
+    {
+        [Test]
+        public async Task ActAsync_with_sync_is_never_triggered()
+        {
+            var result = await Context.Invalid.AsTask().ActAsync(Actions.Failure, Context.Update);
+            ValidationMessageAssert.WithErrors(result, ValidationMessage.Error("InvalidContext"));
+        }
+
+        [Test]
+        public async Task ActAsync_with_async_is_never_triggered()
+        {
+            var result = await Context.Invalid.AsTask().ActAsync(Actions.FailureAsync, Context.Update);
+            ValidationMessageAssert.WithErrors(result, ValidationMessage.Error("InvalidContext"));
+        }
+    }
+
+    internal class Context
+    {
+        public static Task<Result<Context>> NullTask => Task.FromResult<Result<Context>>(null);
+        public static Result<Context> Null => Result.For<Context>(null);
+        public static Result<Context> Valid => Result.For(new Context());
+        public static Result<Context> Invalid => Result.WithMessages<Context>(ValidationMessage.Error("InvalidContext"));
+
+        public string Value { get; set; }
+        public bool Updated => Value is { };
+
+        public static void Update(Context context, string value) => context.Value = value;
+    }
+
+    internal static class Actions
+    {
+        public static Result<string> Success(Context context)
+            => Result.For(nameof(Success));
+
+        public static Task<Result<string>> SuccessAsync(Context context)
+            => Result.For(nameof(SuccessAsync)).AsTask();
+        
+        public static Result<string> Failure(Context context) 
+            => Result.WithMessages<string>(ValidationMessage.Error(nameof(Failure)));
+
+        public static Task<Result<string>> FailureAsync(Context context)
+            => Result.WithMessages<string>(ValidationMessage.Error(nameof(FailureAsync))).AsTask();
+    }
+}

--- a/test/Qowaiv.Validation.Abstractions.UnitTests/Result_Act_specs.cs
+++ b/test/Qowaiv.Validation.Abstractions.UnitTests/Result_Act_specs.cs
@@ -315,13 +315,12 @@ namespace Result_Act_specs
         }
 
         public Task<Result<TestModel>> NonfailingFunctionAsync()
-        {
-            return Task.FromResult(Result.For(new TestModel(Actions + 1)));
-        }
+            => Result.For(new TestModel(Actions + 1)).AsTask();
+
         public Task<Result<TestModel>> FailingFunctionAsync()
         {
             Actions = -Actions;
-            return Task.FromResult(Result.WithMessages<TestModel>(ValidationMessage.Error(nameof(FailingFunctionAsync))));
+            return Result.WithMessages<TestModel>(ValidationMessage.Error(nameof(FailingFunctionAsync))).AsTask();
         }
 
         public Result NonfailingAction()

--- a/test/Qowaiv.Validation.Abstractions.UnitTests/Result_Act_specs.cs
+++ b/test/Qowaiv.Validation.Abstractions.UnitTests/Result_Act_specs.cs
@@ -41,7 +41,7 @@ namespace Result_Act_specs
 
     public class AsyncNullModel
     {
-        internal static Task<Result<TestModel>> ModelAsync() => Task.FromResult(Result.For<TestModel>(null));
+        internal static Task<Result<TestModel>> ModelAsync() => Result.For<TestModel>(null).AsTask();
 
         [Test]
         public async Task ActAsync_with_sync_function_is_never_triggered()
@@ -160,7 +160,7 @@ namespace Result_Act_specs
 
     public class AsyncValidModel
     {
-        internal static Task<Result<TestModel>> ModelAsync() => Task.FromResult(Result.For(new TestModel()));
+        internal static Task<Result<TestModel>> ModelAsync() => Result.For(new TestModel()).AsTask();
 
         [Test]
         public async Task ActAsync_on_sync_nonfailing_function_is_executed_and_result_stays_valid()
@@ -246,7 +246,7 @@ namespace Result_Act_specs
 
     public class AsyncInvalidModel
     {
-        internal static Task<Result<TestModel>> ModelAsync() => Task.FromResult(Result.WithMessages<TestModel>(ValidationMessage.Error("FailingModelAsync")));
+        internal static Task<Result<TestModel>> ModelAsync() => Result.WithMessages<TestModel>(ValidationMessage.Error("FailingModelAsync")).AsTask();
 
         [Test]
         public async Task ActAsync_with_sync_function_is_never_triggered()

--- a/test/Qowaiv.Validation.Abstractions.UnitTests/Result_specs.cs
+++ b/test/Qowaiv.Validation.Abstractions.UnitTests/Result_specs.cs
@@ -91,4 +91,21 @@ namespace Result_specs
         public void As_Task_with_AsTask()
             => Assert.That(Result.For(17).AsTask(), Is.InstanceOf<Task<Result<int>>>());
     }
+
+    public class ThrowIfInvalid
+    {
+        [Test]
+        public void Nothing_when_valid()
+        {
+            Assert.That(() => Result.For(17).ThrowIfInvalid(), Throws.Nothing);
+        }
+
+        [Test]
+        public void InvalidModelException_when_invalid()
+        {
+            Assert.That(
+                () => Result.WithMessages<int>(ValidationMessage.Error("Oops")).ThrowIfInvalid()
+                , Throws.InstanceOf<InvalidModelException>());
+        }
+    }
 }


### PR DESCRIPTION
To support scenario's like these:

``` C#
Result<Context> context = NewContext()
    .Act(c => Service.GetValue(), (c, value) => c.Value = value)
    .Act(c => Service.GetOther(), (c, other) => c.Value = other);
```