### PR TITLE
Improve on Invalid model exception message

### DIFF
--- a/src/Qowaiv.Validation.Abstractions/InvalidModelException.cs
+++ b/src/Qowaiv.Validation.Abstractions/InvalidModelException.cs
@@ -45,32 +45,29 @@ namespace Qowaiv.Validation.Abstractions
             info.AddValue(nameof(Errors), Errors.ToArray());
         }
 
-        /// <inheritdoc />
-        public override string ToString()
-        {
-            var sb = new StringBuilder().AppendLine(base.ToString());
-            foreach (var error in Errors)
-            {
-                sb.Append(error.Message);
-                if (!string.IsNullOrEmpty(error.PropertyName))
-                {
-                    sb.Append(" (").Append(error.PropertyName).AppendLine(")");
-                }
-                else
-                {
-                    sb.AppendLine();
-                }
-            }
-            return sb.ToString();
-        }
-
         /// <summary>The related validation error(s).</summary>
         public IReadOnlyList<IValidationMessage> Errors { get; } = new ReadOnlyCollection<IValidationMessage>(new IValidationMessage[0]);
 
         /// <summary>Creates an <see cref="InvalidModelException"/> for the model.</summary>
         public static InvalidModelException For<T>(IEnumerable<IValidationMessage> messages)
         {
-            return new InvalidModelException(string.Format(QowaivValidationMessages.InvalidModelException, typeof(T)), null, messages);
+            var sb = new StringBuilder().AppendFormat(QowaivValidationMessages.InvalidModelException, typeof(T));
+            
+            foreach(var message in messages ?? Array.Empty<IValidationMessage>())
+            {
+                if (!string.IsNullOrEmpty(message.Message))
+                {
+                    sb.Append("* ");
+                    var lines = message.Message.Split(NewLine, StringSplitOptions.None);
+                    sb.AppendLine(lines[0]);
+                    foreach(var line in lines.Skip(1))
+                    {
+                        sb.Append("  ").AppendLine(line);
+                    }
+                }
+            }
+            return new InvalidModelException(sb.ToString(), null, messages);
         }
+        private static readonly string[] NewLine = new[] { "\r\n", "\n" };
     }
 }

--- a/src/Qowaiv.Validation.Abstractions/InvalidModelException.cs
+++ b/src/Qowaiv.Validation.Abstractions/InvalidModelException.cs
@@ -25,7 +25,7 @@ namespace Qowaiv.Validation.Abstractions
         /// <summary>Initializes a new instance of the <see cref="InvalidModelException"/> class.</summary>
         public InvalidModelException(string message, Exception innerException, IEnumerable<IValidationMessage> messages)
             : this(message, innerException)
-            => Errors = new ReadOnlyCollection<IValidationMessage>(messages.Where(e => e.Severity >= ValidationSeverity.Error).ToArray());
+            => Errors = new ReadOnlyCollection<IValidationMessage>(Filter(messages).ToArray());
 
         /// <summary>Initializes a new instance of the <see cref="InvalidModelException"/> class.</summary>
         protected InvalidModelException(SerializationInfo info, StreamingContext context)
@@ -52,22 +52,38 @@ namespace Qowaiv.Validation.Abstractions
         public static InvalidModelException For<T>(IEnumerable<IValidationMessage> messages)
         {
             var sb = new StringBuilder().AppendFormat(QowaivValidationMessages.InvalidModelException, typeof(T));
-            
-            foreach(var message in messages ?? Array.Empty<IValidationMessage>())
+            var filtered = Filter(messages);
+
+            if (filtered.Any())
             {
-                if (!string.IsNullOrEmpty(message.Message))
+                sb.Remove(sb.Length - 1, 1).AppendLine(":");
+                foreach (var message in filtered)
                 {
-                    sb.Append("* ");
-                    var lines = message.Message.Split(NewLine, StringSplitOptions.None);
-                    sb.AppendLine(lines[0]);
-                    foreach(var line in lines.Skip(1))
-                    {
-                        sb.Append("  ").AppendLine(line);
-                    }
+                    Append(sb, message);
                 }
             }
             return new InvalidModelException(sb.ToString(), null, messages);
         }
+
+        private static IEnumerable<IValidationMessage> Filter(IEnumerable<IValidationMessage> messages)
+            => (messages ?? Array.Empty<IValidationMessage>())
+            .Where(e => e.Severity >= ValidationSeverity.Error);
+
+        private static void Append(StringBuilder builder, IValidationMessage message)
+        {
+            var text = string.IsNullOrWhiteSpace(message.Message)
+                ? "Validation Error."
+                : message.Message.Trim();
+            var lines = text.Split(NewLine, StringSplitOptions.None);
+            builder
+                .Append("* ")
+                .Append(string.Join(Environment.NewLine + "  ", lines))
+                .AppendLine(PropertySuffix(message));
+        }
+
+        private static string PropertySuffix(IValidationMessage message)
+            => string.IsNullOrWhiteSpace(message.PropertyName) ? string.Empty : $" ({message.PropertyName})";
+
         private static readonly string[] NewLine = new[] { "\r\n", "\n" };
     }
 }

--- a/test/Qowaiv.Validation.Abstractions.UnitTests/Exception_specs.cs
+++ b/test/Qowaiv.Validation.Abstractions.UnitTests/Exception_specs.cs
@@ -8,21 +8,46 @@ namespace Exception_specs
     public class InvalidModel
     {
         [Test]
-        public void Contains_the_error_messages_in_the_ToString()
+        public void Null_messages_is_fine()
         {
-            var str = InvalidModelException.For<int>(new IValidationMessage[]
+            var exception = InvalidModelException.For<int>(null);
+            Assert.That(exception.Message, Is.EqualTo("The System.Int32 model can not be operated on as it is invalid."));
+        }
+
+        [Test]
+        public void No_list_without_errors_specified()
+        {
+            var exception = InvalidModelException.For<int>(new IValidationMessage[]
+            {
+                ValidationMessage.None,
+            });
+            Assert.That(exception.Message, Is.EqualTo("The System.Int32 model can not be operated on as it is invalid."));
+        }
+        
+        [Test]
+        public void Contains_the_error_messages_in_Message()
+        {
+            var exception = InvalidModelException.For<int>(new IValidationMessage[]
             {
                 ValidationMessage.None,
                 ValidationMessage.Error("Not a prime", "_value"),
+                ValidationMessage.Error("Multi-line\nmessage.", "multi-line"),
+                ValidationMessage.Error("No property specified."),
+                ValidationMessage.Error("  ", "no-message"),
                 ValidationMessage.Warn("Small", "_value"),
                 ValidationMessage.Info("Not my favorite", "_value"),
                 ValidationMessage.Error("Not a multiple of 17", "_value"),
-            }).ToString();
+            });
 
-            Assert.AreEqual(@"Qowaiv.Validation.Abstractions.InvalidModelException: The System.Int32 model can not be operated on as it is invalid.
-Not a prime (_value)
-Not a multiple of 17 (_value)
-", str);
+            Assert.That(exception.Message, Is.EqualTo(
+                @"The System.Int32 model can not be operated on as it is invalid:
+* Not a prime (_value)
+* Multi-line
+  message. (multi-line)
+* No property specified.
+* Validation Error. (no-message)
+* Not a multiple of 17 (_value)
+"));
         }
 
         [Test]


### PR DESCRIPTION
As what validation errors caused the error to occur only where rendered in the ToString(), and not in the messages, most systems do not show what is wrong. Therefore, this logic is moved to generation of the message.