### PR TITLE
Clock validation (Fluent) should be available for DateOnly

### DIFF
--- a/src/Qowaiv.Validation.Fluent/FluentValidation/ClockValidation.cs
+++ b/src/Qowaiv.Validation.Fluent/FluentValidation/ClockValidation.cs
@@ -1,7 +1,7 @@
 ﻿namespace FluentValidation;
 
 /// <summary>Fluent validation for <see cref="Clock"/>.</summary>
-public static class ClockValidation
+public static partial class ClockValidation
 {
     /// <summary>Requires a date time to be in the future.</summary>
     /// <typeparam name="TModel">

--- a/src/Qowaiv.Validation.Fluent/FluentValidation/ClockValidation.net6.0.cs
+++ b/src/Qowaiv.Validation.Fluent/FluentValidation/ClockValidation.net6.0.cs
@@ -1,0 +1,185 @@
+﻿#if NET6_0_OR_GREATER
+
+namespace FluentValidation;
+
+/// <summary>Fluent validation for <see cref="Clock"/>.</summary>
+public static partial class ClockValidation
+{
+    /// <summary>Requires a date to be in the future.</summary>
+    /// <typeparam name="TModel">
+    /// Type of the model being validated.
+    /// </typeparam>
+    /// <param name="ruleBuilder">
+    /// The rule builder on which the validator should be defined.
+    /// </param>
+    /// <param name="today">
+    /// An optional function providing today, or if not specified, <see cref="Clock.Today()"/>.
+    /// </param>
+    [FluentSyntax]
+    public static IRuleBuilderOptions<TModel, DateOnly> InFuture<TModel>(this IRuleBuilder<TModel, DateOnly> ruleBuilder, Func<Date> today = null)
+    {
+        Guard.NotNull(ruleBuilder, nameof(ruleBuilder));
+
+        today ??= Clock.Today;
+
+        return ruleBuilder
+            .Must(date => date > today())
+            .WithMessage(m => QowaivValidationFluentMessages.InFuture);
+    }
+
+    /// <summary>Requires a date to be in the future (if set).</summary>
+    /// <typeparam name="TModel">
+    /// Type of the model being validated.
+    /// </typeparam>
+    /// <param name="ruleBuilder">
+    /// The rule builder on which the validator should be defined.
+    /// </param>
+    /// <param name="today">
+    /// An optional function providing today, or if not specified, <see cref="Clock.Today()"/>.
+    /// </param>
+    [FluentSyntax]
+    public static IRuleBuilderOptions<TModel, DateOnly?> InFuture<TModel>(this IRuleBuilder<TModel, DateOnly?> ruleBuilder, Func<Date> today = null)
+    {
+        Guard.NotNull(ruleBuilder, nameof(ruleBuilder));
+
+        today ??= Clock.Today;
+
+        return ruleBuilder
+            .Must(date => !date.HasValue || date.Value > today())
+            .WithMessage(m => QowaivValidationFluentMessages.InFuture);
+    }
+
+    /// <summary>Requires a date not to be in the future.</summary>
+    /// <typeparam name="TModel">
+    /// Type of the model being validated.
+    /// </typeparam>
+    /// <param name="ruleBuilder">
+    /// The rule builder on which the validator should be defined.
+    /// </param>
+    /// <param name="today">
+    /// An optional function providing today, or if not specified, <see cref="Clock.Today()"/>.
+    /// </param>
+    [FluentSyntax]
+    public static IRuleBuilderOptions<TModel, DateOnly> NotInFuture<TModel>(this IRuleBuilder<TModel, DateOnly> ruleBuilder, Func<Date> today = null)
+    {
+        Guard.NotNull(ruleBuilder, nameof(ruleBuilder));
+
+        today ??= Clock.Today;
+
+        return ruleBuilder
+            .Must(date => date <= today())
+            .WithMessage(m => QowaivValidationFluentMessages.NotInFuture);
+    }
+
+    /// <summary>Requires a date not to be in the future (if set).</summary>
+    /// <typeparam name="TModel">
+    /// Type of the model being validated.
+    /// </typeparam>
+    /// <param name="ruleBuilder">
+    /// The rule builder on which the validator should be defined.
+    /// </param>
+    /// <param name="today">
+    /// An optional function providing today, or if not specified, <see cref="Clock.Today()"/>.
+    /// </param>
+    [FluentSyntax]
+    public static IRuleBuilderOptions<TModel, DateOnly?> NotInFuture<TModel>(this IRuleBuilder<TModel, DateOnly?> ruleBuilder, Func<Date> today = null)
+    {
+        Guard.NotNull(ruleBuilder, nameof(ruleBuilder));
+
+        today ??= Clock.Today;
+
+        return ruleBuilder
+            .Must(date => !date.HasValue || date.Value <= today())
+            .WithMessage(m => QowaivValidationFluentMessages.NotInFuture);
+    }
+
+    /// <summary>Requires a date to be in the past.</summary>
+    /// <typeparam name="TModel">
+    /// Type of the model being validated.
+    /// </typeparam>
+    /// <param name="ruleBuilder">
+    /// The rule builder on which the validator should be defined.
+    /// </param>
+    /// <param name="today">
+    /// An optional function providing today, or if not specified, <see cref="Clock.Today()"/>.
+    /// </param>
+    [FluentSyntax]
+    public static IRuleBuilderOptions<TModel, DateOnly> InPast<TModel>(this IRuleBuilder<TModel, DateOnly> ruleBuilder, Func<Date> today = null)
+    {
+        Guard.NotNull(ruleBuilder, nameof(ruleBuilder));
+
+        today ??= Clock.Today;
+
+        return ruleBuilder
+            .Must(date => date < today())
+            .WithMessage(m => QowaivValidationFluentMessages.InPast);
+    }
+
+    /// <summary>Requires a date to be in the past (if set).</summary>
+    /// <typeparam name="TModel">
+    /// Type of the model being validated.
+    /// </typeparam>
+    /// <param name="ruleBuilder">
+    /// The rule builder on which the validator should be defined.
+    /// </param>
+    /// <param name="today">
+    /// An optional function providing today, or if not specified, <see cref="Clock.Today()"/>.
+    /// </param>
+    [FluentSyntax]
+    public static IRuleBuilderOptions<TModel, DateOnly?> InPast<TModel>(this IRuleBuilder<TModel, DateOnly?> ruleBuilder, Func<Date> today = null)
+    {
+        Guard.NotNull(ruleBuilder, nameof(ruleBuilder));
+
+        today ??= Clock.Today;
+
+        return ruleBuilder
+            .Must(date => !date.HasValue || date.Value < today())
+            .WithMessage(m => QowaivValidationFluentMessages.InPast);
+    }
+
+    /// <summary>Requires a date not to be in the past.</summary>
+    /// <typeparam name="TModel">
+    /// Type of the model being validated.
+    /// </typeparam>
+    /// <param name="ruleBuilder">
+    /// The rule builder on which the validator should be defined.
+    /// </param>
+    /// <param name="today">
+    /// An optional function providing today, or if not specified, <see cref="Clock.Today()"/>.
+    /// </param>
+    [FluentSyntax]
+    public static IRuleBuilderOptions<TModel, DateOnly> NotInPast<TModel>(this IRuleBuilder<TModel, DateOnly> ruleBuilder, Func<Date> today = null)
+    {
+        Guard.NotNull(ruleBuilder, nameof(ruleBuilder));
+
+        today ??= Clock.Today;
+
+        return ruleBuilder
+            .Must(date => date >= today())
+            .WithMessage(m => QowaivValidationFluentMessages.NotInPast);
+    }
+
+    /// <summary>Requires a date not to be in the past (if set).</summary>
+    /// <typeparam name="TModel">
+    /// Type of the model being validated.
+    /// </typeparam>
+    /// <param name="ruleBuilder">
+    /// The rule builder on which the validator should be defined.
+    /// </param>
+    /// <param name="today">
+    /// An optional function providing today, or if not specified, <see cref="Clock.Today()"/>.
+    /// </param>
+    [FluentSyntax]
+    public static IRuleBuilderOptions<TModel, DateOnly?> NotInPast<TModel>(this IRuleBuilder<TModel, DateOnly?> ruleBuilder, Func<Date> today = null)
+    {
+        Guard.NotNull(ruleBuilder, nameof(ruleBuilder));
+
+        today ??= Clock.Today;
+
+        return ruleBuilder
+            .Must(date => !date.HasValue || date.Value >= today())
+            .WithMessage(m => QowaivValidationFluentMessages.NotInPast);
+    }
+}
+
+#endif

--- a/test/Qowaiv.Validation.Fluent.UnitTests/Models/DateTimeModels.cs
+++ b/test/Qowaiv.Validation.Fluent.UnitTests/Models/DateTimeModels.cs
@@ -4,13 +4,24 @@ public class DateTimeModel
 {
     public DateTime Prop { get; set; }
 }
+
 public class DateModel
 {
     public Date Prop { get; set; }
 }
+
+public class DateOnlyModel
+{
+    public DateOnly Prop { get; set; }
+}
+
 public class NullableDateModel
 {
     public Date? Prop { get; set; }
+}
+public class NullableDateOnlyModel
+{
+    public DateOnly? Prop { get; set; }
 }
 
 public class NullableDateTimeModel

--- a/test/Qowaiv.Validation.Fluent.UnitTests/Validators/InFuture_specs.cs
+++ b/test/Qowaiv.Validation.Fluent.UnitTests/Validators/InFuture_specs.cs
@@ -12,6 +12,15 @@ public class Valid_for_in_future
     }
 
     [Test]
+    public void DateOnly()
+    {
+        using (Clock.SetTimeForCurrentThread(() => new Date(2017, 06, 11)))
+        {
+            new DateOnlyModel { Prop = new DateOnly(2017, 06, 12) }.Should().BeValidFor(new DateOnlyInFutureValidator());
+        }
+    }
+
+    [Test]
     public void DateTime()
     {
         using (Clock.SetTimeForCurrentThread(() => new Date(2017, 06, 11)))
@@ -30,11 +39,20 @@ public class Valid_for_in_future
     }
 
     [Test]
+    public void Nullable_DateOnly()
+    {
+        using (Clock.SetTimeForCurrentThread(() => new Date(2017, 06, 11)))
+        {
+            new NullableDateOnlyModel { Prop = new DateOnly(2017, 06, 12) }.Should().BeValidFor(new NullableDateOnlyInFutureValidator());
+        }
+    }
+
+    [Test]
     public void Nullable_DateTime()
     {
         using (Clock.SetTimeForCurrentThread(() => new Date(2017, 06, 11)))
         {
-            new NullableDateTimeModel { Prop = new Date(2017, 06, 12) }.Should().BeValidFor(new NullableDateTimeInFutureValidator());
+            new NullableDateTimeModel { Prop = new DateTime(2017, 06, 12) }.Should().BeValidFor(new NullableDateTimeInFutureValidator());
         }
     }
 }
@@ -47,6 +65,15 @@ public class Not_invalid_for_not_set
         using (Clock.SetTimeForCurrentThread(() => new Date(2017, 06, 11)))
         {
             new NullableDateModel { Prop = null }.Should().BeValidFor(new NullableDateInFutureValidator());
+        }
+    }
+
+    [Test]
+    public void DateOnly()
+    {
+        using (Clock.SetTimeForCurrentThread(() => new Date(2017, 06, 11)))
+        {
+            new NullableDateOnlyModel { Prop = null }.Should().BeValidFor(new NullableDateOnlyInFutureValidator());
         }
     }
 
@@ -79,13 +106,28 @@ public class Invalid_for_not_in_future
 
     [TestCase("'Prop' moet in de toekomst liggen.", "nl-NL")]
     [TestCase("'Prop' should be in the future.", "en-GB")]
+    public void DateOnly(string message, CultureInfo culture)
+    {
+        using (culture.Scoped())
+        {
+            using (Clock.SetTimeForCurrentThread(() => new Date(2017, 06, 11)))
+            {
+                new DateOnlyModel { Prop = new DateOnly(2017, 06, 11) }.Should()
+                    .BeInvalidFor(new DateOnlyInFutureValidator())
+                    .WithMessage(ValidationMessage.Error(message, "Prop"));
+            }
+        }
+    }
+
+    [TestCase("'Prop' moet in de toekomst liggen.", "nl-NL")]
+    [TestCase("'Prop' should be in the future.", "en-GB")]
     public void DateTime(string message, CultureInfo culture)
     {
         using (culture.Scoped())
         {
             using (Clock.SetTimeForCurrentThread(() => new Date(2017, 06, 11)))
             {
-                new DateTimeModel { Prop = new Date(2017, 06, 11) }.Should()
+                new DateTimeModel { Prop = new DateTime(2017, 06, 11) }.Should()
                     .BeInvalidFor(new DateTimeInFutureValidator())
                     .WithMessage(ValidationMessage.Error(message, "Prop"));
             }
@@ -109,13 +151,28 @@ public class Invalid_for_not_in_future
 
     [TestCase("'Prop' moet in de toekomst liggen.", "nl-NL")]
     [TestCase("'Prop' should be in the future.", "en-GB")]
+    public void Nullable_DateOnly(string message, CultureInfo culture)
+    {
+        using (culture.Scoped())
+        {
+            using (Clock.SetTimeForCurrentThread(() => new Date(2017, 06, 11)))
+            {
+                new NullableDateOnlyModel { Prop = new DateOnly(2017, 06, 11) }.Should()
+                    .BeInvalidFor(new NullableDateOnlyInFutureValidator())
+                    .WithMessage(ValidationMessage.Error(message, "Prop"));
+            }
+        }
+    }
+
+    [TestCase("'Prop' moet in de toekomst liggen.", "nl-NL")]
+    [TestCase("'Prop' should be in the future.", "en-GB")]
     public void Nullable_DateTime(string message, CultureInfo culture)
     {
         using (culture.Scoped())
         {
             using (Clock.SetTimeForCurrentThread(() => new Date(2017, 06, 11)))
             {
-                new NullableDateTimeModel { Prop = new Date(2017, 06, 11) }.Should()
+                new NullableDateTimeModel { Prop = new DateTime(2017, 06, 11) }.Should()
                     .BeInvalidFor(new NullableDateTimeInFutureValidator())
                     .WithMessage(ValidationMessage.Error(message, "Prop"));
             }
@@ -128,9 +185,19 @@ public class DateInFutureValidator : ModelValidator<DateModel>
     public DateInFutureValidator() => RuleFor(m => m.Prop).InFuture();
 }
 
+public class DateOnlyInFutureValidator : ModelValidator<DateOnlyModel>
+{
+    public DateOnlyInFutureValidator() => RuleFor(m => m.Prop).InFuture();
+}
+
 public class DateTimeInFutureValidator : ModelValidator<DateTimeModel>
 {
     public DateTimeInFutureValidator() => RuleFor(m => m.Prop).InFuture();
+}
+
+public class NullableDateOnlyInFutureValidator : ModelValidator<NullableDateOnlyModel>
+{
+    public NullableDateOnlyInFutureValidator() => RuleFor(m => m.Prop).InFuture();
 }
 
 public class NullableDateInFutureValidator : ModelValidator<NullableDateModel>

--- a/test/Qowaiv.Validation.Fluent.UnitTests/Validators/InPast_specs.cs
+++ b/test/Qowaiv.Validation.Fluent.UnitTests/Validators/InPast_specs.cs
@@ -12,6 +12,16 @@ public class Valid_for_in_past
     }
 
     [Test]
+    public void DateOnly()
+    {
+        using (Clock.SetTimeForCurrentThread(() => new Date(2017, 06, 11)))
+        {
+            new DateOnlyModel { Prop = new DateOnly(2017, 06, 10) }.Should().BeValidFor(new DateOnlyInPastValidator());
+        }
+    }
+
+
+    [Test]
     public void DateTime()
     {
         using (Clock.SetTimeForCurrentThread(() => new Date(2017, 06, 11)))
@@ -26,6 +36,15 @@ public class Valid_for_in_past
         using (Clock.SetTimeForCurrentThread(() => new Date(2017, 06, 11)))
         {
             new NullableDateModel { Prop = new Date(2017, 06, 10) }.Should().BeValidFor(new NullableDateInPastValidator());
+        }
+    }
+
+    [Test]
+    public void Nullable_DateOnly()
+    {
+        using (Clock.SetTimeForCurrentThread(() => new Date(2017, 06, 11)))
+        {
+            new NullableDateOnlyModel { Prop = new DateOnly(2017, 06, 10) }.Should().BeValidFor(new NullableDateOnlyInPastValidator());
         }
     }
 
@@ -50,6 +69,15 @@ public class Not_invalid_for_not_set
     }
 
     [Test]
+    public void DateOnly()
+    {
+        using (Clock.SetTimeForCurrentThread(() => new Date(2017, 06, 11)))
+        {
+            new NullableDateOnlyModel { Prop = null }.Should().BeValidFor(new NullableDateOnlyInPastValidator());
+        }
+    }
+
+    [Test]
     public void DateTime()
     {
         using (Clock.SetTimeForCurrentThread(() => new Date(2017, 06, 11)))
@@ -70,6 +98,21 @@ public class Invalid_for_not_past
             {
                 new DateModel { Prop = new Date(2017, 06, 12) }.Should()
                     .BeInvalidFor(new DateInPastValidator())
+                    .WithMessage(ValidationMessage.Error(message, "Prop"));
+            }
+        }
+    }
+
+    [TestCase("'Prop' moet in het verleden liggen.", "nl-NL")]
+    [TestCase("'Prop' should be in the past.", "en-GB")]
+    public void DateOnly(string message, CultureInfo culture)
+    {
+        using (culture.Scoped())
+        {
+            using (Clock.SetTimeForCurrentThread(() => new Date(2017, 06, 11)))
+            {
+                new DateOnlyModel { Prop = new DateOnly(2017, 06, 12) }.Should()
+                    .BeInvalidFor(new DateOnlyInPastValidator())
                     .WithMessage(ValidationMessage.Error(message, "Prop"));
             }
         }
@@ -107,6 +150,21 @@ public class Invalid_for_not_past
 
     [TestCase("'Prop' moet in het verleden liggen.", "nl-NL")]
     [TestCase("'Prop' should be in the past.", "en-GB")]
+    public void Nullable_DateOnly(string message, CultureInfo culture)
+    {
+        using (culture.Scoped())
+        {
+            using (Clock.SetTimeForCurrentThread(() => new Date(2017, 06, 11)))
+            {
+                new NullableDateOnlyModel { Prop = new DateOnly(2017, 06, 12) }.Should()
+                    .BeInvalidFor(new NullableDateOnlyInPastValidator())
+                    .WithMessage(ValidationMessage.Error(message, "Prop"));
+            }
+        }
+    }
+
+    [TestCase("'Prop' moet in het verleden liggen.", "nl-NL")]
+    [TestCase("'Prop' should be in the past.", "en-GB")]
     public void Nullable_DateTime(string message, CultureInfo culture)
     {
         using (culture.Scoped())
@@ -126,6 +184,11 @@ public class DateInPastValidator : ModelValidator<DateModel>
     public DateInPastValidator() => RuleFor(m => m.Prop).InPast();
 }
 
+public class DateOnlyInPastValidator : ModelValidator<DateOnlyModel>
+{
+    public DateOnlyInPastValidator() => RuleFor(m => m.Prop).InPast();
+}
+
 public class DateTimeInPastValidator : ModelValidator<DateTimeModel>
 {
     public DateTimeInPastValidator() => RuleFor(m => m.Prop).InPast();
@@ -134,6 +197,11 @@ public class DateTimeInPastValidator : ModelValidator<DateTimeModel>
 public class NullableDateInPastValidator : ModelValidator<NullableDateModel>
 {
     public NullableDateInPastValidator() => RuleFor(m => m.Prop).InPast();
+}
+
+public class NullableDateOnlyInPastValidator : ModelValidator<NullableDateOnlyModel>
+{
+    public NullableDateOnlyInPastValidator() => RuleFor(m => m.Prop).InPast();
 }
 
 public class NullableDateTimeInPastValidator : ModelValidator<NullableDateTimeModel>

--- a/test/Qowaiv.Validation.Fluent.UnitTests/Validators/NotInFuture_specs.cs
+++ b/test/Qowaiv.Validation.Fluent.UnitTests/Validators/NotInFuture_specs.cs
@@ -1,6 +1,4 @@
-﻿using Qowaiv.Validation.Fluent;
-
-namespace Validation.NotInFuture_specs
+﻿namespace Validation.NotInFuture_specs
 {
     public class Valid_for_not_in_future
     {
@@ -12,6 +10,16 @@ namespace Validation.NotInFuture_specs
                 new DateModel { Prop = new Date(2017, 06, 10) }.Should().BeValidFor(new DateNotInFutureValidator());
             }
         }
+
+        [Test]
+        public void DateOnly()
+        {
+            using (Clock.SetTimeForCurrentThread(() => new Date(2017, 06, 11)))
+            {
+                new DateOnlyModel { Prop = new DateOnly(2017, 06, 10) }.Should().BeValidFor(new DateOnlyNotInFutureValidator());
+            }
+        }
+
 
         [Test]
         public void DateTime()
@@ -28,6 +36,15 @@ namespace Validation.NotInFuture_specs
             using (Clock.SetTimeForCurrentThread(() => new Date(2017, 06, 11)))
             {
                 new NullableDateModel { Prop = new Date(2017, 06, 10) }.Should().BeValidFor(new NullableDateNotInFutureValidator());
+            }
+        }
+
+        [Test]
+        public void Nullable_DateOnly()
+        {
+            using (Clock.SetTimeForCurrentThread(() => new Date(2017, 06, 11)))
+            {
+                new NullableDateOnlyModel { Prop = new Date(2017, 06, 10) }.Should().BeValidFor(new NullableDateOnlyNotInFutureValidator());
             }
         }
 
@@ -53,6 +70,15 @@ namespace Validation.NotInFuture_specs
         }
 
         [Test]
+        public void DateOnly()
+        {
+            using (Clock.SetTimeForCurrentThread(() => new Date(2017, 06, 11)))
+            {
+                new NullableDateOnlyModel { Prop = null }.Should().BeValidFor(new NullableDateOnlyNotInFutureValidator());
+            }
+        }
+
+        [Test]
         public void DateTime()
         {
             using (Clock.SetTimeForCurrentThread(() => new Date(2017, 06, 11)))
@@ -74,6 +100,21 @@ namespace Validation.NotInFuture_specs
                 {
                     new DateModel { Prop = new Date(2017, 06, 12) }.Should()
                         .BeInvalidFor(new DateNotInFutureValidator())
+                        .WithMessage(ValidationMessage.Error(message, "Prop"));
+                }
+            }
+        }
+
+        [TestCase("'Prop' mag niet in de toekomst liggen.", "nl-NL")]
+        [TestCase("'Prop' should not be in the future.", "en-GB")]
+        public void DateOnly(string message, CultureInfo culture)
+        {
+            using (culture.Scoped())
+            {
+                using (Clock.SetTimeForCurrentThread(() => new Date(2017, 06, 11)))
+                {
+                    new DateOnlyModel { Prop = new Date(2017, 06, 12) }.Should()
+                        .BeInvalidFor(new DateOnlyNotInFutureValidator())
                         .WithMessage(ValidationMessage.Error(message, "Prop"));
                 }
             }
@@ -111,6 +152,21 @@ namespace Validation.NotInFuture_specs
 
         [TestCase("'Prop' mag niet in de toekomst liggen.", "nl-NL")]
         [TestCase("'Prop' should not be in the future.", "en-GB")]
+        public void Nullable_DateOnly(string message, CultureInfo culture)
+        {
+            using (culture.Scoped())
+            {
+                using (Clock.SetTimeForCurrentThread(() => new Date(2017, 06, 11)))
+                {
+                    new NullableDateOnlyModel { Prop = new Date(2017, 06, 12) }.Should()
+                        .BeInvalidFor(new NullableDateOnlyNotInFutureValidator())
+                        .WithMessage(ValidationMessage.Error(message, "Prop"));
+                }
+            }
+        }
+
+        [TestCase("'Prop' mag niet in de toekomst liggen.", "nl-NL")]
+        [TestCase("'Prop' should not be in the future.", "en-GB")]
         public void Nullable_DateTime(string message, CultureInfo culture)
         {
             using (culture.Scoped())
@@ -130,6 +186,11 @@ namespace Validation.NotInFuture_specs
         public DateNotInFutureValidator() => RuleFor(m => m.Prop).NotInFuture();
     }
 
+    public class DateOnlyNotInFutureValidator : ModelValidator<DateOnlyModel>
+    {
+        public DateOnlyNotInFutureValidator() => RuleFor(m => m.Prop).NotInFuture();
+    }
+
     public class DateTimeNotInFutureValidator : ModelValidator<DateTimeModel>
     {
         public DateTimeNotInFutureValidator() => RuleFor(m => m.Prop).NotInFuture();
@@ -138,6 +199,11 @@ namespace Validation.NotInFuture_specs
     public class NullableDateNotInFutureValidator : ModelValidator<NullableDateModel>
     {
         public NullableDateNotInFutureValidator() => RuleFor(m => m.Prop).NotInFuture();
+    }
+
+    public class NullableDateOnlyNotInFutureValidator : ModelValidator<NullableDateOnlyModel>
+    {
+        public NullableDateOnlyNotInFutureValidator() => RuleFor(m => m.Prop).NotInFuture();
     }
 
     public class NullableDateTimeNotInFutureValidator : ModelValidator<NullableDateTimeModel>

--- a/test/Qowaiv.Validation.Fluent.UnitTests/Validators/NotInPast_specs.cs
+++ b/test/Qowaiv.Validation.Fluent.UnitTests/Validators/NotInPast_specs.cs
@@ -12,6 +12,15 @@ public class Valid_for_in_past
     }
 
     [Test]
+    public void DateOnly()
+    {
+        using (Clock.SetTimeForCurrentThread(() => new Date(2017, 06, 11)))
+        {
+            new DateOnlyModel { Prop = new DateOnly(2017, 06, 11) }.Should().BeValidFor(new DateOnlyNotInPastValidator());
+        }
+    }
+
+    [Test]
     public void DateTime()
     {
         using (Clock.SetTimeForCurrentThread(() => new DateTime(2017, 06, 11)))
@@ -26,6 +35,15 @@ public class Valid_for_in_past
         using (Clock.SetTimeForCurrentThread(() => new Date(2017, 06, 11)))
         {
             new NullableDateModel { Prop = new Date(2017, 06, 11) }.Should().BeValidFor(new NullableDateNotInPastValidator());
+        }
+    }
+
+    [Test]
+    public void Nullable_DateOnly()
+    {
+        using (Clock.SetTimeForCurrentThread(() => new Date(2017, 06, 11)))
+        {
+            new NullableDateOnlyModel { Prop = new DateOnly(2017, 06, 11) }.Should().BeValidFor(new NullableDateOnlyNotInPastValidator());
         }
     }
 
@@ -50,6 +68,15 @@ public class Not_invalid_for_not_set
     }
 
     [Test]
+    public void DateOnly()
+    {
+        using (Clock.SetTimeForCurrentThread(() => new Date(2017, 06, 11)))
+        {
+            new NullableDateOnlyModel { Prop = null }.Should().BeValidFor(new NullableDateOnlyNotInPastValidator());
+        }
+    }
+
+    [Test]
     public void DateTime()
     {
         using (Clock.SetTimeForCurrentThread(() => new Date(2017, 06, 11)))
@@ -70,6 +97,21 @@ public class Invalid_for_not_past
             {
                 new DateModel { Prop = new Date(2017, 06, 10) }.Should()
                     .BeInvalidFor(new DateNotInPastValidator())
+                    .WithMessage(ValidationMessage.Error(message, "Prop"));
+            }
+        }
+    }
+
+    [TestCase("'Prop' mag niet in het verleden liggen.", "nl-NL")]
+    [TestCase("'Prop' should not be in the past.", "en-GB")]
+    public void DateOnly(string message, CultureInfo culture)
+    {
+        using (culture.Scoped())
+        {
+            using (Clock.SetTimeForCurrentThread(() => new Date(2017, 06, 11)))
+            {
+                new DateOnlyModel { Prop = new DateOnly(2017, 06, 10) }.Should()
+                    .BeInvalidFor(new DateOnlyNotInPastValidator())
                     .WithMessage(ValidationMessage.Error(message, "Prop"));
             }
         }
@@ -107,6 +149,21 @@ public class Invalid_for_not_past
 
     [TestCase("'Prop' mag niet in het verleden liggen.", "nl-NL")]
     [TestCase("'Prop' should not be in the past.", "en-GB")]
+    public void Nullable_DateOnly(string message, CultureInfo culture)
+    {
+        using (culture.Scoped())
+        {
+            using (Clock.SetTimeForCurrentThread(() => new Date(2017, 06, 11)))
+            {
+                new NullableDateOnlyModel { Prop = new DateOnly(2017, 06, 10) }.Should()
+                    .BeInvalidFor(new NullableDateOnlyNotInPastValidator())
+                    .WithMessage(ValidationMessage.Error(message, "Prop"));
+            }
+        }
+    }
+
+    [TestCase("'Prop' mag niet in het verleden liggen.", "nl-NL")]
+    [TestCase("'Prop' should not be in the past.", "en-GB")]
     public void Nullable_DateTime(string message, CultureInfo culture)
     {
         using (culture.Scoped())
@@ -126,6 +183,11 @@ public class DateNotInPastValidator : ModelValidator<DateModel>
     public DateNotInPastValidator() => RuleFor(m => m.Prop).NotInPast();
 }
 
+public class DateOnlyNotInPastValidator : ModelValidator<DateOnlyModel>
+{
+    public DateOnlyNotInPastValidator() => RuleFor(m => m.Prop).NotInPast();
+}
+
 public class DateTimeNotInPastValidator : ModelValidator<DateTimeModel>
 {
     public DateTimeNotInPastValidator() => RuleFor(m => m.Prop).NotInPast();
@@ -134,6 +196,11 @@ public class DateTimeNotInPastValidator : ModelValidator<DateTimeModel>
 public class NullableDateNotInPastValidator : ModelValidator<NullableDateModel>
 {
     public NullableDateNotInPastValidator() => RuleFor(m => m.Prop).NotInPast();
+}
+
+public class NullableDateOnlyNotInPastValidator : ModelValidator<NullableDateOnlyModel>
+{
+    public NullableDateOnlyNotInPastValidator() => RuleFor(m => m.Prop).NotInPast();
 }
 
 public class NullableDateTimeNotInPastValidator : ModelValidator<NullableDateTimeModel>


### PR DESCRIPTION
For .NET 6.0 and up, `InPast`, `NotInPast`, `InFuture`, and `NotInFuture` should also be available for `DateOnly`.