### PR TITLE
Validating models using DataAnnotations should always be nested

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,15 +348,12 @@ public class Model
 
 #### NestedModel attribute
 The `AnnotatedModelValidator` of this packages support nested validation.
-Microsoft's default implementation doesn't. The validator will only do that if
-a class has been decorated as such.
 
 ``` C#
 public class NestedModelWithChildren
 {
     public ChildModel[] Children { get; set; }
 
-    [NestedModel()]
     public class ChildModel
     {
         [Mandatory()]

--- a/src/Qowaiv.Validation.DataAnnotations/AnnotatedModelValidator.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/AnnotatedModelValidator.cs
@@ -111,14 +111,10 @@ public class AnnotatedModelValidator<TModel> : IValidator<TModel>
                     ValidateModel(nestedContext);
                 }
             }
-            else if (property.IsNestedModel)
+            else
             {
                 var nestedContext = propertyContext.Nested(value);
                 ValidateModel(nestedContext);
-            }
-            else
-            {
-                // Else we can skip further validation.
             }
         }
     }

--- a/src/Qowaiv.Validation.DataAnnotations/AnnotatedProperty.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/AnnotatedProperty.cs
@@ -1,39 +1,39 @@
-﻿namespace Qowaiv.Validation.DataAnnotations
+﻿namespace Qowaiv.Validation.DataAnnotations;
+
+/// <summary>Represents a property that contains at least one <see cref="ValidationAttribute"/>.</summary>
+[DebuggerDisplay("{DebuggerDisplay}")]
+public class AnnotatedProperty
 {
-    /// <summary>Represents a property that contains at least one <see cref="ValidationAttribute"/>.</summary>
-    [DebuggerDisplay("{DebuggerDisplay}")]
-    public class AnnotatedProperty
+    /// <summary>The underlying descriptor.</summary>
+    private readonly PropertyDescriptor descriptor;
+
+    /// <summary>Initializes a new instance of the <see cref="AnnotatedProperty"/> class.</summary>
+    private AnnotatedProperty(PropertyDescriptor desc)
     {
-        /// <summary>The underlying descriptor.</summary>
-        private readonly PropertyDescriptor descriptor;
+        descriptor = desc;
+        DisplayAttribute = desc.GetDisplayAttribute() ?? new DisplayAttribute { Name = desc.Name };
+        RequiredAttribute = desc.GetRequiredAttribute() ?? OptionalAttribute.Optional;
+        ValidationAttributes = desc.GetValidationAttributes().Except(new[] { RequiredAttribute }).ToArray();
+        IsEnumerable = PropertyType != typeof(string)
+            && PropertyType != typeof(byte[])
+            && GetEnumerableType(PropertyType) is not null;
+    }
 
-        /// <summary>Initializes a new instance of the <see cref="AnnotatedProperty"/> class.</summary>
-        private AnnotatedProperty(PropertyDescriptor desc)
-        {
-            descriptor = desc;
-            DisplayAttribute = desc.GetDisplayAttribute() ?? new DisplayAttribute { Name = desc.Name };
-            RequiredAttribute = desc.GetRequiredAttribute() ?? OptionalAttribute.Optional;
-            ValidationAttributes = desc.GetValidationAttributes().Except(new[] { RequiredAttribute }).ToArray();
-            IsEnumerable = PropertyType != typeof(string)
-                && PropertyType != typeof(byte[])
-                && GetEnumerableType(PropertyType) is not null;
-            IsNestedModel = desc.Attributes[typeof(NestedModelAttribute)] != null;
-        }
+    /// <summary>Gets the type of the property.</summary>
+    public Type PropertyType => descriptor.PropertyType;
 
-        /// <summary>Gets the type of the property.</summary>
-        public Type PropertyType => descriptor.PropertyType;
+    /// <summary>Gets the name of the property.</summary>
+    public string Name => descriptor.Name;
 
-        /// <summary>Gets the name of the property.</summary>
-        public string Name => descriptor.Name;
+    /// <summary>True if the property is read-only, otherwise false.</summary>
+    public bool IsReadOnly => descriptor.IsReadOnly;
 
-        /// <summary>True if the property is read-only, otherwise false.</summary>
-        public bool IsReadOnly => descriptor.IsReadOnly;
+    /// <summary>True if the property is an <see cref="IEnumerable{T}"/> type, otherwise false.</summary>
+    public bool IsEnumerable { get; }
 
-        /// <summary>True if the property is an <see cref="IEnumerable{T}"/> type, otherwise false.</summary>
-        public bool IsEnumerable { get; }
-
-        /// <summary>True if the model is decorated with the <see cref="NestedModelAttribute"/>, otherwise false.</summary>
-        public bool IsNestedModel { get; }
+    /// <summary>Always true.</summary>
+    [Obsolete("Not longer used. Will be dropped.")]
+    public bool IsNestedModel => true;
 
         /// <summary>Gets the type converter associated with the property.</summary>
         /// <remarks>
@@ -42,52 +42,51 @@
         [Obsolete("Not longer used, will be dropped.")]
         public TypeConverter TypeConverter => descriptor.GetTypeConverter();
 
-        /// <summary>Gets the display attribute.</summary>
-        /// <remarks>
-        /// Returns a display attribute with the name equal to the property name if not decorated.
-        /// </remarks>
-        public DisplayAttribute DisplayAttribute { get; }
+    /// <summary>Gets the display attribute.</summary>
+    /// <remarks>
+    /// Returns a display attribute with the name equal to the property name if not decorated.
+    /// </remarks>
+    public DisplayAttribute DisplayAttribute { get; }
 
-        /// <summary>Gets the required attribute.</summary>
-        /// <remarks>
-        /// <see cref="OptionalAttribute"/> if the property is not decorated.
-        /// </remarks>
-        public RequiredAttribute RequiredAttribute { get; }
+    /// <summary>Gets the required attribute.</summary>
+    /// <remarks>
+    /// <see cref="OptionalAttribute"/> if the property is not decorated.
+    /// </remarks>
+    public RequiredAttribute RequiredAttribute { get; }
 
-        /// <summary>Gets the <see cref="ValidationAttribute"/>s the property
-        /// is decorated with.
-        /// </summary>
-        public IReadOnlyCollection<ValidationAttribute> ValidationAttributes { get; }
+    /// <summary>Gets the <see cref="ValidationAttribute"/>s the property
+    /// is decorated with.
+    /// </summary>
+    public IReadOnlyCollection<ValidationAttribute> ValidationAttributes { get; }
 
-        /// <summary>Gets the value of the property for the specified model.</summary>
-        [Pure]
-        public object GetValue(object model) => descriptor.GetValue(model);
+    /// <summary>Gets the value of the property for the specified model.</summary>
+    [Pure]
+    public object GetValue(object model) => descriptor.GetValue(model);
 
-        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        internal string DebuggerDisplay
-            => $"{descriptor.PropertyType} {descriptor.Name}, Attributes: {string.Join(", ", GetAll().Select(a => Shorten(a)))}";
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    internal string DebuggerDisplay
+        => $"{descriptor.PropertyType} {descriptor.Name}, Attributes: {string.Join(", ", GetAll().Select(a => Shorten(a)))}";
 
-        [Pure]
-        private IEnumerable<ValidationAttribute> GetAll() => Enumerable.Repeat(RequiredAttribute, 1).Concat(ValidationAttributes);
+    [Pure]
+    private IEnumerable<ValidationAttribute> GetAll() => Enumerable.Repeat(RequiredAttribute, 1).Concat(ValidationAttributes);
 
-        [Pure]
-        private static string Shorten(Attribute attr) => attr.GetType().Name.Replace("Attribute", string.Empty);
+    [Pure]
+    private static string Shorten(Attribute attr) => attr.GetType().Name.Replace("Attribute", string.Empty);
 
-        /// <summary>Creates a <see cref="AnnotatedProperty"/> for all annotated properties.</summary>
-        [Pure]
-        internal static IEnumerable<AnnotatedProperty> CreateAll(Type type)
-            => TypeDescriptor
-            .GetProperties(type)
-            .Cast<PropertyDescriptor>()
-            .Select(desc => new AnnotatedProperty(desc));
+    /// <summary>Creates a <see cref="AnnotatedProperty"/> for all annotated properties.</summary>
+    [Pure]
+    internal static IEnumerable<AnnotatedProperty> CreateAll(Type type)
+        => TypeDescriptor
+        .GetProperties(type)
+        .Cast<PropertyDescriptor>()
+        .Select(desc => new AnnotatedProperty(desc));
 
-        [Pure]
-        private static Type GetEnumerableType(Type type)
-            => type
-            .GetInterfaces()
-            .FirstOrDefault(iface =>
-                iface.IsGenericType &&
-                iface.GetGenericTypeDefinition() == typeof(IEnumerable<>))?
-            .GetGenericArguments()[0];
-    }
+    [Pure]
+    private static Type GetEnumerableType(Type type)
+        => type
+        .GetInterfaces()
+        .FirstOrDefault(iface =>
+            iface.IsGenericType &&
+            iface.GetGenericTypeDefinition() == typeof(IEnumerable<>))?
+        .GetGenericArguments()[0];
 }

--- a/src/Qowaiv.Validation.DataAnnotations/NestedModelAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/NestedModelAttribute.cs
@@ -3,5 +3,6 @@
 /// <summary>Decorates a class so that the <see cref="AnnotatedModelValidator{Tmodel}"/>
 /// will also validate its children.
 /// </summary>
+[Obsolete("Not longer used. All children will be validated.")]
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = true)]
 public sealed class NestedModelAttribute : Attribute { }

--- a/src/Qowaiv.Validation.DataAnnotations/Qowaiv.Validation.DataAnnotations.csproj
+++ b/src/Qowaiv.Validation.DataAnnotations/Qowaiv.Validation.DataAnnotations.csproj
@@ -4,8 +4,11 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
-    <Version>0.2.2</Version>
+    <Version>0.2.3</Version>
     <PackageReleaseNotes>
+v0.2.3
+- All models are considered to be nested. #52
+- Fix crash on validation models with properties with generic types. #53
 v0.2.2
 - Mandatory attribute supports Dutch messages. #51
 v0.2.1

--- a/test/Qowaiv.Validation.DataAnnotations.UnitTests/Models/NestedModel.cs
+++ b/test/Qowaiv.Validation.DataAnnotations.UnitTests/Models/NestedModel.cs
@@ -1,21 +1,17 @@
-﻿using System;
+﻿namespace Qowaiv.Validation.DataAnnotations.UnitTests.Models;
 
-namespace Qowaiv.Validation.DataAnnotations.UnitTests.Models
+public class NestedModel
 {
-    public class NestedModel
+    [Mandatory]
+    public Guid Id { get; set; }
+
+    [Mandatory]
+    public ChildModel Child { get; set; }
+
+    public class ChildModel
     {
         [Mandatory]
-        public Guid Id { get; set; }
-
-        [Mandatory]
-        public ChildModel Child { get; set; }
-
-        [NestedModel]
-        public class ChildModel
-        {
-            [Mandatory]
-            public string Name { get; set; }
-        }
-
+        public string Name { get; set; }
     }
+
 }

--- a/test/Qowaiv.Validation.DataAnnotations.UnitTests/Models/NestedModelWithChildren.cs
+++ b/test/Qowaiv.Validation.DataAnnotations.UnitTests/Models/NestedModelWithChildren.cs
@@ -1,30 +1,25 @@
-﻿using System;
+﻿namespace Qowaiv.Validation.DataAnnotations.UnitTests.Models;
 
-namespace Qowaiv.Validation.DataAnnotations.UnitTests.Models
+public class NestedModelWithChildren
 {
-    public class NestedModelWithChildren
+    [Mandatory]
+    public Guid Id { get; set; }
+
+    [Mandatory]
+    public ChildModel[] Children { get; set; }
+
+    public class ChildModel
     {
         [Mandatory]
-        public Guid Id { get; set; }
+        public string ChildName { get; set; }
 
+        [Optional]
+        public GrandchildModel[] Grandchildren { get; set; }
+    }
+
+    public class GrandchildModel
+    {
         [Mandatory]
-        public ChildModel[] Children { get; set; }
-
-        [NestedModel]
-        public class ChildModel
-        {
-            [Mandatory]
-            public string ChildName { get; set; }
-
-            [Optional]
-            public GrandchildModel[] Grandchildren { get; set; }
-        }
-
-        [NestedModel]
-        public class GrandchildModel
-        {
-            [Mandatory]
-            public string GrandchildName { get; set; }
-        }
+        public string GrandchildName { get; set; }
     }
 }

--- a/test/Qowaiv.Validation.DataAnnotations.UnitTests/Models/NestedModelWithLoop.cs
+++ b/test/Qowaiv.Validation.DataAnnotations.UnitTests/Models/NestedModelWithLoop.cs
@@ -1,22 +1,18 @@
-﻿using System;
+﻿namespace Qowaiv.Validation.DataAnnotations.UnitTests.Models;
 
-namespace Qowaiv.Validation.DataAnnotations.UnitTests.Models
+public class NestedModelWithLoop
 {
-    public class NestedModelWithLoop
+    [Mandatory]
+    public Guid Id { get; set; }
+
+    [Mandatory]
+    public ChildModel Child { get; set; }
+
+    public class ChildModel
     {
         [Mandatory]
-        public Guid Id { get; set; }
+        public string Name { get; set; }
 
-        [Mandatory]
-        public ChildModel Child { get; set; }
-
-        [NestedModel]
-        public class ChildModel
-        {
-            [Mandatory]
-            public string Name { get; set; }
-
-            public NestedModelWithLoop Parent { get; set; }
-        }
+        public NestedModelWithLoop Parent { get; set; }
     }
 }


### PR DESCRIPTION
Enforcing models to have a `[NestedModel]` is undesirable; it is the default (and basically the only) desired behaviour. 