### PR TITLE
Support Warnings as errors on result

### DIFF
--- a/props/common.props
+++ b/props/common.props
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.40.0.48530">
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.42.0.51121">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/specs/Qowaiv.Validation.Specs/Qowaiv.Validation.Specs.csproj
+++ b/specs/Qowaiv.Validation.Specs/Qowaiv.Validation.Specs.csproj
@@ -16,13 +16,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.6.0" />
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
     <PackageReference Include="FluentAssertions.Analyzers" Version="0.17.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="nunit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Qowaiv.Validation.Abstractions/Result.cs
+++ b/src/Qowaiv.Validation.Abstractions/Result.cs
@@ -18,8 +18,21 @@ public class Result
     [Pure]
     public bool IsValid => !Errors.Any();
 
-    /// <summary>Gets all messages with <see cref="ValidationSeverity.Error"/>.</summary>
+    /// <summary>Returns a result where all warnings are converted into error messages.</summary>
+    /// <remarks>
+    /// The type of the messages that where warnings might change due to this.
+    /// </remarks>
+    [Pure]
+    public Result WarningsAsErrors() 
+        => new(FixedMessages.Empty.AddRange(Messages.Select(WarningAsError)));
 
+    [Pure]
+    static internal IValidationMessage WarningAsError(IValidationMessage message)
+        => message.Severity == ValidationSeverity.Warning
+        ? ValidationMessage.Error(message.Message!, message.PropertyName)
+        : message;
+
+    /// <summary>Gets all messages with <see cref="ValidationSeverity.Error"/>.</summary>
     [Pure]
     public IEnumerable<IValidationMessage> Errors => Messages.GetErrors();
 

--- a/src/Qowaiv.Validation.Abstractions/Result_TModel.cs
+++ b/src/Qowaiv.Validation.Abstractions/Result_TModel.cs
@@ -29,6 +29,14 @@ public sealed class Result<TModel> : Result
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private readonly TModel? _value;
 
+    /// <summary>Returns a result where all warnings are converted into error messages.</summary>
+    /// <remarks>
+    /// The type of the messages that where warnings might change due to this.
+    /// </remarks>
+    [Pure]
+    public new Result<TModel> WarningsAsErrors()
+        => new(FixedMessages.Empty.AddRange(Messages.Select(WarningAsError)));
+
     /// <summary>Implicitly casts a model to the <see cref="Result"/>.</summary>
     [Pure]
     public static implicit operator Result<TModel>(TModel model) => For(model);

--- a/src/Qowaiv.Validation.DataAnnotations/AnnotatedModelStore.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/AnnotatedModelStore.cs
@@ -9,11 +9,11 @@ public sealed class AnnotatedModelStore
     internal AnnotatedModelStore()
     {
         _models = new ConcurrentDictionary<Type, AnnotatedModel>(new Dictionary<Type, AnnotatedModel>
-            {
-                { typeof(Guid), AnnotatedModel.None },
-                { typeof(DateTime), AnnotatedModel.None },
-                { typeof(DateTimeOffset), AnnotatedModel.None },
-            });
+        {
+            { typeof(Guid), AnnotatedModel.None },
+            { typeof(DateTime), AnnotatedModel.None },
+            { typeof(DateTimeOffset), AnnotatedModel.None },
+        });
         foreach (var tp in typeof(Date).Assembly.GetTypes().Where(tp => tp.IsValueType && tp.IsVisible))
         {
             _models[tp] = AnnotatedModel.None;
@@ -35,7 +35,7 @@ public sealed class AnnotatedModelStore
         {
             return AnnotatedModel.None;
         }
-        if (!_models.TryGetValue(tp, out AnnotatedModel model))
+        if (!_models.TryGetValue(tp, out var model))
         {
             model = AnnotatedModel.Create(tp);
             _models[type] = model;

--- a/src/Qowaiv.Validation.TestTools/Qowaiv.Validation.TestTools.csproj
+++ b/src/Qowaiv.Validation.TestTools/Qowaiv.Validation.TestTools.csproj
@@ -31,7 +31,7 @@ v0.0.2
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.6.0" />
+    <PackageReference Include="FluentAssertions" Version="6.7.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
There should be a way to convert warnings to errors on a `Result` and a `Result<T>`.