### PR TITLE
Add robustness to validating a model using data annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 | version                                                                       | package                                                                                             |
 |-------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------|
 |![v](https://img.shields.io/badge/version-0.2.1-darkblue.svg?cacheSeconds=3600)|[Qowaiv.Validation.Abstractions](https://www.nuget.org/packages/Qowaiv.Validation.Abstractions)      |
-|![v](https://img.shields.io/badge/version-1.0.0-blue.svg?cacheSeconds=3600)    |[Qowaiv.Validation.DataAnnotations](https://www.nuget.org/packages/Qowaiv.Validation.DataAnnotations)|
+|![v](https://img.shields.io/badge/version-1.0.1-blue.svg?cacheSeconds=3600)    |[Qowaiv.Validation.DataAnnotations](https://www.nuget.org/packages/Qowaiv.Validation.DataAnnotations)|
 |![v](https://img.shields.io/badge/version-0.2.1-blue.svg?cacheSeconds=3600)    |[Qowaiv.Validation.Fluent](https://www.nuget.org/packages/Qowaiv.Validation.Fluent)                  |
 |![v](https://img.shields.io/badge/version-0.2.1-blue.svg?cacheSeconds=3600)    |[Qowaiv.Validation.Guarding](https://www.nuget.org/packages/Qowaiv.Validation.Guarding)              |
 |![v](https://img.shields.io/badge/version-0.2.1-blue.svg?cacheSeconds=3600)    |[Qowaiv.Validation.Messages](https://www.nuget.org/packages/Qowaiv.Validation.Messages)              |

--- a/specs/Qowaiv.Validation.Specs/DataAnnotations/Annotated_model_specs.cs
+++ b/specs/Qowaiv.Validation.Specs/DataAnnotations/Annotated_model_specs.cs
@@ -17,6 +17,12 @@ public class Does_not_crash_on
        .Validate(new())
        .Should().BeValid();
 
+    [Test]
+    public void set_only_property()
+      => new AnnotatedModelValidator<ModelWithSetOnlyProperty>()
+      .Validate(new())
+      .Should().BeValid();
+
     class ModelWithInaccassibleProperty
     {
         public int SomeProperty => throw new NotImplementedException();
@@ -25,6 +31,14 @@ public class Does_not_crash_on
     class ModelWithIndexedProperty
     {
         public int this[int index] => index * 42;
+    }
+
+    class ModelWithSetOnlyProperty
+    {
+        public int SomeProperty
+        {
+            set => Console.WriteLine(value);
+        }
     }
 }
 

--- a/specs/Qowaiv.Validation.Specs/DataAnnotations/Annotated_model_specs.cs
+++ b/specs/Qowaiv.Validation.Specs/DataAnnotations/Annotated_model_specs.cs
@@ -23,22 +23,26 @@ public class Does_not_crash_on
       .Validate(new())
       .Should().BeValid();
 
-    class ModelWithInaccassibleProperty
+    public class ModelWithInaccassibleProperty
     {
         public int SomeProperty => throw new NotImplementedException();
     }
 
-    class ModelWithIndexedProperty
+    public class ModelWithIndexedProperty
     {
         public int this[int index] => index * 42;
     }
 
-    class ModelWithSetOnlyProperty
+    public class ModelWithSetOnlyProperty
     {
+#pragma warning disable S2376 // Write-only properties should not be used
+        // This is a test to check if write-only properties are handled correctly.
         public int SomeProperty
         {
-            set => Console.WriteLine(value);
+            set => number = value;
         }
+        private int number;
+#pragma warning restore S2376 // Write-only properties should not be used
     }
 }
 

--- a/specs/Qowaiv.Validation.Specs/DataAnnotations/Annotated_model_specs.cs
+++ b/specs/Qowaiv.Validation.Specs/DataAnnotations/Annotated_model_specs.cs
@@ -6,7 +6,7 @@ public class Does_not_crash_on
 {
     [Test]
     public void inaccessible_property()
-        => new AnnotatedModelValidator<ModelWithInaccassibleProperty>()
+        => new AnnotatedModelValidator<ModelWithInaccessibleProperty>()
         .Validate(new())
         .Should().BeInvalid()
         .WithMessage(ValidationMessage.Error("The value is inaccessible.", "SomeProperty"));
@@ -23,7 +23,7 @@ public class Does_not_crash_on
       .Validate(new())
       .Should().BeValid();
 
-    public class ModelWithInaccassibleProperty
+    public class ModelWithInaccessibleProperty
     {
         public int SomeProperty => throw new NotImplementedException();
     }

--- a/specs/Qowaiv.Validation.Specs/DataAnnotations/Annotated_model_specs.cs
+++ b/specs/Qowaiv.Validation.Specs/DataAnnotations/Annotated_model_specs.cs
@@ -2,6 +2,49 @@
 
 namespace Data_annotations.Annotated_model_specs;
 
+public class Does_not_crash_on
+{
+    [Test]
+    public void inaccessible_property()
+        => new AnnotatedModelValidator<ModelWithInaccassibleProperty>()
+        .Validate(new())
+        .Should().BeInvalid()
+        .WithMessage(ValidationMessage.Error("The value is inaccessible.", "SomeProperty"));
+
+    [Test]
+    public void indexed_property()
+       => new AnnotatedModelValidator<ModelWithIndexedProperty>()
+       .Validate(new())
+       .Should().BeValid();
+
+    class ModelWithInaccassibleProperty
+    {
+        public int SomeProperty => throw new NotImplementedException();
+    }
+
+    class ModelWithIndexedProperty
+    {
+        public int this[int index] => index * 42;
+    }
+}
+
+public class Has_no_properties_for
+{
+    [TestCase(typeof(int))]
+    [TestCase(typeof(double))]
+    [TestCase(typeof(bool))]
+    public void primitives(Type primitive)
+        => AnnotatedModel.Get(primitive).Properties.Should().BeEmpty();
+
+    [Test]
+    public void @string()
+        => AnnotatedModel.Get(typeof(string)).Properties.Should().BeEmpty();
+
+    [Test]
+    public void enums()
+        => AnnotatedModel.Get(typeof(TypeCode)).Properties.Should().BeEmpty();
+}
+
 public  class With_debugger_experience
 {
     [Test]

--- a/specs/Qowaiv.Validation.Specs/DataAnnotations/Validation_message_specs.cs
+++ b/specs/Qowaiv.Validation.Specs/DataAnnotations/Validation_message_specs.cs
@@ -1,7 +1,7 @@
 ﻿using Qowaiv.Validation.DataAnnotations;
 using ValidationSeverity = Qowaiv.Validation.Abstractions.ValidationSeverity;
 
-namespace Data_annotations.ValidationMessage_specs;
+namespace Data_annotations.Validation_message_specs;
 
 public class Serializes
 {

--- a/src/Qowaiv.Validation.DataAnnotations/AnnotatedModel.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/AnnotatedModel.cs
@@ -50,7 +50,7 @@ public sealed class AnnotatedModel
     /// This one uses caching.
     /// </remarks>
     [Pure]
-    public static AnnotatedModel Get(Type type) => Store.GetAnnotededModel(type);
+    public static AnnotatedModel Get(Type type) => Store.GetAnnotatedModel(type);
 
     /// <summary>Creates an <see cref="AnnotatedModel"/>.</summary>
     [Pure]

--- a/src/Qowaiv.Validation.DataAnnotations/AnnotatedModelStore.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/AnnotatedModelStore.cs
@@ -26,7 +26,7 @@ public sealed class AnnotatedModelStore
 
     /// <summary>Gets an <see cref="AnnotatedModel"/> based on the <see cref="Type"/>.</summary>
     [Pure]
-    public AnnotatedModel GetAnnotededModel(Type type)
+    public AnnotatedModel GetAnnotatedModel(Type type)
     {
         Guard.NotNull(type, nameof(type));
 
@@ -43,4 +43,8 @@ public sealed class AnnotatedModelStore
         }
         return model;
     }
+
+    /// <summary>Gets an <see cref="AnnotatedModel"/> based on the <see cref="Type"/>.</summary>
+    [Pure, Obsolete("Use GetAnnotatedModel(type) instead.")]
+    public AnnotatedModel GetAnnotededModel(Type type) => GetAnnotatedModel(type);
 }

--- a/src/Qowaiv.Validation.DataAnnotations/AnnotatedModelStore.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/AnnotatedModelStore.cs
@@ -9,11 +9,12 @@ public sealed class AnnotatedModelStore
     internal AnnotatedModelStore()
     {
         _models = new ConcurrentDictionary<Type, AnnotatedModel>(new Dictionary<Type, AnnotatedModel>
-            {
-                { typeof(Guid), AnnotatedModel.None },
-                { typeof(DateTime), AnnotatedModel.None },
-                { typeof(DateTimeOffset), AnnotatedModel.None },
-            });
+        {
+            { typeof(string), AnnotatedModel.None },
+            { typeof(Guid), AnnotatedModel.None },
+            { typeof(DateTime), AnnotatedModel.None },
+            { typeof(DateTimeOffset), AnnotatedModel.None },
+        });
         foreach (var tp in typeof(Date).Assembly.GetTypes().Where(tp => tp.IsValueType && tp.IsVisible))
         {
             _models[tp] = AnnotatedModel.None;

--- a/src/Qowaiv.Validation.DataAnnotations/AnnotatedModelValidator.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/AnnotatedModelValidator.cs
@@ -85,9 +85,18 @@ public class AnnotatedModelValidator<TModel> : IValidator<TModel>
     private void ValidateProperty(AnnotatedProperty property, NestedValidationContext context)
     {
         var model = context.Instance;
-        var value = property.GetValue(model);
-
         var propertyContext = context.ForProperty(property);
+
+        object? value;
+        try
+        {
+            value = property.GetValue(model);
+        }
+        catch
+        {
+            propertyContext.AddMessage(ValidationMessage.Error($"The value is inaccessible.", property.Name));
+            return;
+        }
 
         // Only validate the other properties if the required condition was not met.
         if (propertyContext.AddMessage(property.RequiredAttribute.GetValidationMessage(value, propertyContext)))
@@ -142,7 +151,7 @@ public class AnnotatedModelValidator<TModel> : IValidator<TModel>
     private sealed class EmptyProvider : IServiceProvider
     {
         public static readonly EmptyProvider Instance = new();
-        
+
         [Pure]
         public object? GetService(Type serviceType) => null;
     }

--- a/src/Qowaiv.Validation.DataAnnotations/AnnotatedProperty.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/AnnotatedProperty.cs
@@ -61,6 +61,11 @@ public sealed class AnnotatedProperty
     [Pure]
     internal static IEnumerable<AnnotatedProperty> CreateAll(Type type)
         => type.GetProperties()
-        .Where(property => !property.GetIndexParameters().Any())
+        .Where(Include)
         .Select(property => new AnnotatedProperty(property));
+
+    [Pure]
+    private static bool Include(PropertyInfo property)
+        => property.CanRead
+        && !property.GetIndexParameters().Any();
 }

--- a/src/Qowaiv.Validation.DataAnnotations/AnnotatedProperty.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/AnnotatedProperty.cs
@@ -61,5 +61,6 @@ public sealed class AnnotatedProperty
     [Pure]
     internal static IEnumerable<AnnotatedProperty> CreateAll(Type type)
         => type.GetProperties()
+        .Where(property => !property.GetIndexParameters().Any())
         .Select(property => new AnnotatedProperty(property));
 }

--- a/src/Qowaiv.Validation.DataAnnotations/Qowaiv.Validation.DataAnnotations.csproj
+++ b/src/Qowaiv.Validation.DataAnnotations/Qowaiv.Validation.DataAnnotations.csproj
@@ -4,8 +4,11 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <PackageReleaseNotes>
+v1.0.1
+- Inaccessible properties do not crash but validate as invalid #57
+- Indexed properties are ignored
 v1.0.0
 - Properties are considered validatable objects without [NestedModel] attribute #55
 - Removed unused properties from NestedModel

--- a/src/Qowaiv.Validation.DataAnnotations/Qowaiv.Validation.DataAnnotations.csproj
+++ b/src/Qowaiv.Validation.DataAnnotations/Qowaiv.Validation.DataAnnotations.csproj
@@ -7,7 +7,7 @@
     <Version>1.0.1</Version>
     <PackageReleaseNotes>
 v1.0.1
-- Inaccessible properties do not crash but validate as invalid #57
+- Inaccessible properties do not crash but validate as invalid #58
 - Indexed properties are ignored
 v1.0.0
 - Properties are considered validatable objects without [NestedModel] attribute #55


### PR DESCRIPTION
It turns out that the following model can not be validated with Data Annotations without crashing:

``` C#
class MyModel: IEnumerable<string>
{
    // ...
}
```
First of all, contrary to the assumption, `typeof(string).IsPrimitive` turns out toe be false, not true. Therefor, An annotated model was created. That resulted in adding properties with an index (`public char this[int index] { get; }`) to be added, what was the real issue: `property.GetValue(model)` throws, as no index was specified. Logically, properties with one (or multiple) indexes should be excluded from the properties to include.

As an extra step of robustness, if `property.GetValue()` throws, the exception is caught. In that case an validation error is added, mentioning that the property x is inaccessible. The exception itself is not communicated as it might expose security issues. Furthermore, from the validators point of view, the model could not be fully validated and is therefore invalid.

