### PR TITLE
Support Cast on Result<T>

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 
 | version                                                                       | package                                                                                             |
 |-------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------|
-|![v](https://img.shields.io/badge/version-0.2.1-darkblue.svg?cacheSeconds=3600)|[Qowaiv.Validation.Abstractions](https://www.nuget.org/packages/Qowaiv.Validation.Abstractions)      |
-|![v](https://img.shields.io/badge/version-1.0.1-blue.svg?cacheSeconds=3600)    |[Qowaiv.Validation.DataAnnotations](https://www.nuget.org/packages/Qowaiv.Validation.DataAnnotations)|
-|![v](https://img.shields.io/badge/version-0.2.1-blue.svg?cacheSeconds=3600)    |[Qowaiv.Validation.Fluent](https://www.nuget.org/packages/Qowaiv.Validation.Fluent)                  |
-|![v](https://img.shields.io/badge/version-0.2.1-blue.svg?cacheSeconds=3600)    |[Qowaiv.Validation.Guarding](https://www.nuget.org/packages/Qowaiv.Validation.Guarding)              |
-|![v](https://img.shields.io/badge/version-0.2.1-blue.svg?cacheSeconds=3600)    |[Qowaiv.Validation.Messages](https://www.nuget.org/packages/Qowaiv.Validation.Messages)              |
-|![v](https://img.shields.io/badge/version-0.2.1-blue.svg?cacheSeconds=3600)    |[Qowaiv.Validation.Xml](https://www.nuget.org/packages/Qowaiv.Validation.Xml)                        |
-|![v](https://img.shields.io/badge/version-0.2.1-darkred.svg?cacheSeconds=3600) |[Qowaiv.Validation.TestTools](https://www.nuget.org/packages/Qowaiv.TestTools)                       |
+|![v](https://img.shields.io/badge/version-0.3.0-darkblue.svg?cacheSeconds=3600)|[Qowaiv.Validation.Abstractions](https://www.nuget.org/packages/Qowaiv.Validation.Abstractions)      |
+|![v](https://img.shields.io/badge/version-1.3.0-blue.svg?cacheSeconds=3600)    |[Qowaiv.Validation.DataAnnotations](https://www.nuget.org/packages/Qowaiv.Validation.DataAnnotations)|
+|![v](https://img.shields.io/badge/version-0.3.0-blue.svg?cacheSeconds=3600)    |[Qowaiv.Validation.Fluent](https://www.nuget.org/packages/Qowaiv.Validation.Fluent)                  |
+|![v](https://img.shields.io/badge/version-0.3.0-blue.svg?cacheSeconds=3600)    |[Qowaiv.Validation.Guarding](https://www.nuget.org/packages/Qowaiv.Validation.Guarding)              |
+|![v](https://img.shields.io/badge/version-0.3.0-blue.svg?cacheSeconds=3600)    |[Qowaiv.Validation.Messages](https://www.nuget.org/packages/Qowaiv.Validation.Messages)              |
+|![v](https://img.shields.io/badge/version-0.3.0-blue.svg?cacheSeconds=3600)    |[Qowaiv.Validation.Xml](https://www.nuget.org/packages/Qowaiv.Validation.Xml)                        |
+|![v](https://img.shields.io/badge/version-0.3.0-darkred.svg?cacheSeconds=3600) |[Qowaiv.Validation.TestTools](https://www.nuget.org/packages/Qowaiv.TestTools)                       |
 
 # Qowaiv Validation
 There are multiple ways to support validation within .NET. Most notable are

--- a/README.md
+++ b/README.md
@@ -132,6 +132,16 @@ Result<Context> context = NewContext()
     .Act(c => Service.GetOther(), (c, other) => /* return Context */ c.Update(other));
 ```
 
+#### Casting
+The following castings are supported:
+``` C#
+Result<T> implicit = new T();
+T explicit = Result.For<T>(new T());
+Result<TOut> casted = Result.For<T>(new T()).Cast<TOut>();
+```
+The explicit casts fails if the result was not valid. The `Cast<TOut>()` fails
+when `TOut` is not a subclass of `T`.
+
 ### IValidationMessage
 The common ground of validation messages.
 ``` C#

--- a/specs/Qowaiv.Validation.Specs/Abstractions/Result_specs.cs
+++ b/specs/Qowaiv.Validation.Specs/Abstractions/Result_specs.cs
@@ -111,7 +111,7 @@ public class Casting
     }
 
     [Test]
-    public void With_method_to_Result_of_valid__wiht_subtype_of_T_is_supported()
+    public void With_method_to_Result_of_valid_with_subtype_of_T_is_supported()
     {
         var value = XDocument.Parse("<root />");
         Result.For(value).Cast<XNode>().Should().BeValid()
@@ -126,7 +126,7 @@ public class Casting
     }
 
     [Test]
-    public void With_method_is_not_supported_TOut_not_bein_subtype_of_TModel()
+    public void With_method_is_not_supported_TOut_not_being_subtype_of_TModel()
     {
         Result.For(42).Invoking(r => r.Cast<long>())
             .Should().Throw<InvalidCastException>()

--- a/specs/Qowaiv.Validation.Specs/Abstractions/Result_specs.cs
+++ b/specs/Qowaiv.Validation.Specs/Abstractions/Result_specs.cs
@@ -1,4 +1,5 @@
 ﻿using Qowaiv.Validation.Abstractions;
+using System.Xml.Linq;
 using static Specs.Abstractions.Arrange;
 
 namespace Abstractions.Result_specs;
@@ -99,14 +100,37 @@ public class Casting
     public void Implicit_from_T_to_Result_of_T_is_supported()
     {
         Result<int> result = 17;
-        Assert.That(result.Value, Is.EqualTo(17));
+        result.Should().BeValid().Value.Should().Be(17);
     }
 
     [Test]
     public void Explicit_from_Result_of_T_to_T_is_supported()
     {
         var result = Result.For(666);
-        Assert.That((int)result, Is.EqualTo(666));
+        result.Should().BeValid().Value.Should().Be(666);
+    }
+
+    [Test]
+    public void With_method_to_Result_of_valid__wiht_subtype_of_T_is_supported()
+    {
+        var value = XDocument.Parse("<root />");
+        Result.For(value).Cast<XNode>().Should().BeValid()
+            .Value.Should().BeSameAs(value);
+    }
+
+
+    [Test]
+    public void With_method_to_Result_of_invalid_with_subtype_of_T_is_supported()
+    {
+        Result.WithMessages<XDocument>(Error1).Cast<XNode>().Should().BeInvalid();
+    }
+
+    [Test]
+    public void With_method_is_not_supported_TOut_not_bein_subtype_of_TModel()
+    {
+        Result.For(42).Invoking(r => r.Cast<long>())
+            .Should().Throw<InvalidCastException>()
+            .WithMessage("Unable to cast object of type 'Result<System.Int32>' to type 'Result<System.Int64>'.");
     }
 }
 

--- a/specs/Qowaiv.Validation.Specs/Abstractions/Result_specs.cs
+++ b/specs/Qowaiv.Validation.Specs/Abstractions/Result_specs.cs
@@ -118,20 +118,20 @@ public class Casting
             .Value.Should().BeSameAs(value);
     }
 
+    [Test]
+    public void With_method_of_null_value_with_subtype_of_T_is_supported()
+        => Result.Null<XDocument>().Cast<XNode>().Should().BeValid()
+        .Value.Should().BeNull();
 
     [Test]
     public void With_method_to_Result_of_invalid_with_subtype_of_T_is_supported()
-    {
-        Result.WithMessages<XDocument>(Error1).Cast<XNode>().Should().BeInvalid();
-    }
+        => Result.WithMessages<XDocument>(Error1).Cast<XNode>().Should().BeInvalid();
 
     [Test]
     public void With_method_is_not_supported_TOut_not_being_subtype_of_TModel()
-    {
-        Result.For(42).Invoking(r => r.Cast<long>())
+        => Result.For(42).Invoking(r => r.Cast<long>())
             .Should().Throw<InvalidCastException>()
             .WithMessage("Unable to cast object of type 'Result<System.Int32>' to type 'Result<System.Int64>'.");
-    }
 }
 
 public class Result_Of_TModel

--- a/src/Qowaiv.Validation.Abstractions/Qowaiv.Validation.Abstractions.csproj
+++ b/src/Qowaiv.Validation.Abstractions/Qowaiv.Validation.Abstractions.csproj
@@ -4,12 +4,11 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net5.0;net6.0;net7.0</TargetFrameworks>
-    <Version>0.2.1</Version>
-    <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
-    <Version>0.2.2</Version>
+    <Version>0.3.0</Version>
     <PackageReleaseNotes>
-v0.2.2
-- Add Result&lt;T&gt;.Cast&lt;TOut&gt;(). #50
+v0.3.0
+- Add Result&lt;T&gt;.Cast&lt;TOut&gt;(). #61
+- Support .NET 7.0. #62
 v0.2.1
 - Nullable anotations. #48
 v0.1.3

--- a/src/Qowaiv.Validation.Abstractions/Qowaiv.Validation.Abstractions.csproj
+++ b/src/Qowaiv.Validation.Abstractions/Qowaiv.Validation.Abstractions.csproj
@@ -5,7 +5,11 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net5.0;net6.0;net7.0</TargetFrameworks>
     <Version>0.2.1</Version>
+    <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
+    <Version>0.2.2</Version>
     <PackageReleaseNotes>
+v0.2.2
+- Add Result&lt;T&gt;.Cast&lt;TOut&gt;(). #50
 v0.2.1
 - Nullable anotations. #48
 v0.1.3

--- a/src/Qowaiv.Validation.Abstractions/Result_TModel.cs
+++ b/src/Qowaiv.Validation.Abstractions/Result_TModel.cs
@@ -42,6 +42,24 @@ public sealed class Result<TModel> : Result
         }
     }
 
+    /// <summary>Casts the result of <typeparamref name="TModel"/> to a result of <typeparamref name="TOut"/>.</summary>
+    /// <typeparam name="TOut">
+    /// The new type of the value.
+    /// </typeparam>
+    /// <exception cref="InvalidCastException">
+    /// if <typeparamref name="TOut"/> is not a subtype of <typeparamref name="TModel"/>.
+    /// </exception>
+    [Pure]
+    public Result<TOut> Cast<TOut>()
+    {
+        return For(_value is null ? default! : Cast(), Messages);
+
+        TOut Cast() 
+            => _value is TOut cast
+            ? cast
+            : throw new InvalidCastException($"Unable to cast object of type 'Result<{typeof(TModel)}>' to type 'Result<{typeof(TOut)}>'.");
+    }
+
     /// <summary>Gets the <see cref="Result{TModel}"/> as a <see cref="Task{TResult}"/>.</summary>
     [Pure]
     public Task<Result<TModel>> AsTask() => Task.FromResult(this);

--- a/src/Qowaiv.Validation.Abstractions/Result_TModel.cs
+++ b/src/Qowaiv.Validation.Abstractions/Result_TModel.cs
@@ -52,7 +52,7 @@ public sealed class Result<TModel> : Result
     [Pure]
     public Result<TOut> Cast<TOut>()
     {
-        return For(_value is null ? default! : Cast(), Messages);
+        return new(_value is null ? default : Cast(), (FixedMessages)Messages);
 
         TOut Cast() 
             => _value is TOut cast

--- a/src/Qowaiv.Validation.DataAnnotations/Qowaiv.Validation.DataAnnotations.csproj
+++ b/src/Qowaiv.Validation.DataAnnotations/Qowaiv.Validation.DataAnnotations.csproj
@@ -4,8 +4,10 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net5.0;net6.0;net7.0</TargetFrameworks>
-    <Version>1.0.1</Version>
+    <Version>1.3.0</Version>
     <PackageReleaseNotes>
+v1.3.0
+- Support .NET 7.0. #62
 v1.0.1
 - Inaccessible properties do not crash but validate as invalid #58
 - Indexed properties are ignored

--- a/src/Qowaiv.Validation.Fluent/Qowaiv.Validation.Fluent.csproj
+++ b/src/Qowaiv.Validation.Fluent/Qowaiv.Validation.Fluent.csproj
@@ -4,8 +4,10 @@
   
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net5.0;net6.0;net7.0</TargetFrameworks>
-    <Version>0.2.1</Version>
+    <Version>0.3.0</Version>
     <PackageReleaseNotes>
+v0.3.0
+- Support .NET 7.0. #62
 v0.2.1
 - Nullable anotations. #48
 - , `InPast`, `NotInPast`, `InFuture`, and `NotInFuture` available for `DateOnly`. #49

--- a/src/Qowaiv.Validation.Guarding/Qowaiv.Validation.Guarding.csproj
+++ b/src/Qowaiv.Validation.Guarding/Qowaiv.Validation.Guarding.csproj
@@ -4,8 +4,10 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net5.0;net6.0;net7.0</TargetFrameworks>
-    <Version>0.2.1</Version>
+    <Version>0.3.0</Version>
     <PackageReleaseNotes>
+v0.3.0
+- Support .NET 7.0. #62
 v0.2.1
 - Nullable anotations. #48
 v0.1.2

--- a/src/Qowaiv.Validation.Messages/Qowaiv.Validation.Messages.csproj
+++ b/src/Qowaiv.Validation.Messages/Qowaiv.Validation.Messages.csproj
@@ -4,8 +4,10 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net5.0;net6.0;net7.0</TargetFrameworks>
-    <Version>0.2.1</Version>
+    <Version>0.3.0</Version>
     <PackageReleaseNotes>
+v0.3.0
+- Support .NET 7.0. #62
 v0.2.1
 - Nullable anotations. #48
 v0.1.0

--- a/src/Qowaiv.Validation.TestTools/Qowaiv.Validation.TestTools.csproj
+++ b/src/Qowaiv.Validation.TestTools/Qowaiv.Validation.TestTools.csproj
@@ -4,8 +4,10 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net5.0;net6.0;net7.0</TargetFrameworks>
-    <Version>0.2.1</Version>
+    <Version>0.3.0</Version>
     <PackageReleaseNotes>
+v0.3.0
+- Support .NET 7.0. #62
 v0.2.1
 - Nullable anotations. #48
 v0.1.1

--- a/src/Qowaiv.Validation.Xml/Qowaiv.Validation.Xml.csproj
+++ b/src/Qowaiv.Validation.Xml/Qowaiv.Validation.Xml.csproj
@@ -4,8 +4,10 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net5.0;net6.0;net7.0</TargetFrameworks>
-    <Version>0.2.1</Version>
+    <Version>0.3.0</Version>
     <PackageReleaseNotes>
+v0.3.0
+- Support .NET 7.0. #62
 v0.2.1
 - Support validation via XSD Schemas. #56
     </PackageReleaseNotes>


### PR DESCRIPTION
To support the cast between `Result<T>` and `Result<TOut>` where `TOut` is a subtype of `T`:

``` C#
var result = Result.For<T>(...);
var casted = result.Cast<TOut>();
```