### PR TITLE
Add missing nullable annotations to Must.Exist

### DIFF
--- a/src/Qowaiv.Validation.Guarding/Must.cs
+++ b/src/Qowaiv.Validation.Guarding/Must.cs
@@ -84,7 +84,7 @@ public sealed class Must<TSubject> where TSubject : class
     /// The selector that tries to find the entity based on the subject.
     /// </param>
     [Pure]
-    public Result<TSubject> Exist<TId, TEntity>(TId id, Func<TSubject, TId, TEntity> selector)
+    public Result<TSubject> Exist<TId, TEntity>(TId id, Func<TSubject, TId, TEntity?> selector)
         where TEntity : class
         => Exist(id, selector, null);
 

--- a/src/Qowaiv.Validation.Guarding/Qowaiv.Validation.Guarding.csproj
+++ b/src/Qowaiv.Validation.Guarding/Qowaiv.Validation.Guarding.csproj
@@ -7,7 +7,7 @@
     <Version>0.3.1</Version>
     <PackageReleaseNotes>
 V0.3.1
-- Fixed lacking nullable annotations. #63
+- Fixed lacking nullable annotations. #67
 v0.3.0
 - Support .NET 7.0. #62
 v0.2.1

--- a/src/Qowaiv.Validation.Guarding/Qowaiv.Validation.Guarding.csproj
+++ b/src/Qowaiv.Validation.Guarding/Qowaiv.Validation.Guarding.csproj
@@ -4,8 +4,10 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net5.0;net6.0;net7.0</TargetFrameworks>
-    <Version>0.3.0</Version>
+    <Version>0.3.1</Version>
     <PackageReleaseNotes>
+V0.3.1
+- Fixed lacking nullable annotations. #63
 v0.3.0
 - Support .NET 7.0. #62
 v0.2.1


### PR DESCRIPTION
Checking on things that might be `null` should obviously be marked with a nullable annotation.