### PR TITLE
Introduction of the `[MultipleOf]` validation attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 | version                                                                       | package                                                                                             |
 |-------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------|
 |![v](https://img.shields.io/badge/version-0.3.0-darkblue.svg?cacheSeconds=3600)|[Qowaiv.Validation.Abstractions](https://www.nuget.org/packages/Qowaiv.Validation.Abstractions)      |
-|![v](https://img.shields.io/badge/version-1.3.0-blue.svg?cacheSeconds=3600)    |[Qowaiv.Validation.DataAnnotations](https://www.nuget.org/packages/Qowaiv.Validation.DataAnnotations)|
+|![v](https://img.shields.io/badge/version-1.4.0-blue.svg?cacheSeconds=3600)    |[Qowaiv.Validation.DataAnnotations](https://www.nuget.org/packages/Qowaiv.Validation.DataAnnotations)|
 |![v](https://img.shields.io/badge/version-0.3.0-blue.svg?cacheSeconds=3600)    |[Qowaiv.Validation.Fluent](https://www.nuget.org/packages/Qowaiv.Validation.Fluent)                  |
 |![v](https://img.shields.io/badge/version-0.3.0-blue.svg?cacheSeconds=3600)    |[Qowaiv.Validation.Guarding](https://www.nuget.org/packages/Qowaiv.Validation.Guarding)              |
 |![v](https://img.shields.io/badge/version-0.3.0-blue.svg?cacheSeconds=3600)    |[Qowaiv.Validation.Messages](https://www.nuget.org/packages/Qowaiv.Validation.Messages)              |

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ There are multiple ways to support validation within .NET. Most notable are
 * [FluentValidation.NET](https://fluentvalidation.net)
 
 Qowaiv.Validation aims to provide extensions on top of those that work well when
-using [Qowaiv SVO's](https://github.com/Qowaiv/Qowaiv), and pretent vendor lock-in.
+using [Qowaiv SVO's](https://github.com/Qowaiv/Qowaiv), and prevent vendor lock-in.
 
 
 ## Qowaiv Validation Abstractions
@@ -182,7 +182,6 @@ communicate a `503 - Service Unavailable` response.
 
 ## Qowaiv exensions on [*Fluent Validation](https://fluentvalidation.net/)
 
-
 ### Validators
 
 #### Not unknown
@@ -263,118 +262,12 @@ public class CustomValidator : AbstractValidator<Model>
 }
 ```
 
-## Qowaiv DataAnnotation validation
-
-
-### Validation messages
-The difference with Microsoft's default ValidationResult and ValidationMessages is that in this PR we support a severity: info, warning, or error.
-
-Those messages can be created via factory methods:
-``` C#
-var none = ValidationMessage.None;
-var info = ValidationMessage.Info(message, args);
-var warn = ValidationMessage.Warning(message, args);
-var error = ValidationMessage.Error(message, args);
-```
-
-### Validation attributes
-
-#### Mandatory attribute
-The `RequiredAttribute` does not work for value types. The `MandatoryAttribute`
-does. The default value of the `struct` is not valid. It also is not valid for
-the Unknown value, unless that is explicitly allowed.
-
-``` C#
-public class Model
-{
-    [Mandatory(AllowUnknownValue = true)]
-    public EmailAddress Email { get; set; }
-
-    [Mandatory()]
-    public string SomeString { get; set; }
-}
-```
-
-#### Any attribute
-The `RequiredAttribute` does not work for collections. The `AnyAttribute`
-does. It is only valid as he collection contains at least one item.
-
-``` C#
-public class Model
-{
-    [Any()]
-    public List<int> Numbers { get; set; }
-}
-```
-
-#### AllowedValues attribute
-The `AllowedValuesAttribute` allows to define a subset of allowed values. It
-supports type converters to get the allowed values based on a string value.
-
-``` C#
-public class Model
-{
-    [AllowedValues("DE", "FR", "GB")]
-    public Country CountryOfBirth { get; set; }
-}
-```
-
-#### ForbiddenValues attribute
-The `ForbiddenValuesAttribute` allows to define a subset of forbidden values. It
-supports type converters to get the allowed values based on a string value.
-
-``` C#
-public class Model
-{
-    [ForbiddenValues("US", "IR")]
-    public Country CountryOfBirth { get; set; }
-}
-```
-
-#### DefinedEnumValuesOnly attribute
-The `DefinedEnumValuesOnlyAttribute` limits the allowed values to defined
-enums only. By default it supports all possible combinations of defined enums 
-when dealing with flags, but that can be restricted by setting 
-`OnlyAllowDefinedFlagsCombinations` to true.
-
-``` C#
-public class Model
-{
-    [DefinedEnumValuesOnly(OnlyAllowDefinedFlagsCombinations = false)]
-    public SomeEnum CountryOfBirth { get; set; }
-}
-```
-
-#### DistinctValues attribute
-The `DistinctValuesAttribute` validates that all items of the collection are
-distinct. If needed, a custom `IEqualityComparer` comparer can be defined.
-
-``` C#
-public class Model
-{
-    [DistinctValues(typeof(CustomEqualityComparer))]
-    public IEnumerable<int> Numbers { get; set; }
-}
-```
-
-#### NestedModel attribute
-The `AnnotatedModelValidator` of this packages support nested validation.
-
-``` C#
-public class NestedModelWithChildren
-{
-    public ChildModel[] Children { get; set; }
-
-    public class ChildModel
-    {
-        [Mandatory()]
-        public string Name { get; set; }
-    }
-}
-```
+## Qowaiv DataAnnotations based validation
+Provides an data annotations based implementation of the `Qowaiv.Validation.Abstractions.IValidator`
+and data annotation attributes [(..)](src/Qowaiv.Validation.DataAnnotations/README.md).
 
 ## XML validation
-Valdating XML documents via XSD schemas is a common scenario. To benefit from
+Validating XML documents via XSD schema's is a common scenario. To benefit from
 `Result<T>` the following scenario is supported:
 
 ``` C#

--- a/specs/Qowaiv.Validation.Specs/DataAnnotations/Attributes/Multiple_of_specs.cs
+++ b/specs/Qowaiv.Validation.Specs/DataAnnotations/Attributes/Multiple_of_specs.cs
@@ -5,12 +5,34 @@ namespace Data_Annotations.Attributes.Multiple_of_specs;
 
 public class Valid_for
 {
-    [TestCase("45.000", 5.000)]
-    [TestCase("45.000", 1.000)]
-    [TestCase("45.100", 0.100)]
-    [TestCase("45.170", 0.010)]
-    [TestCase("45.178", 0.001)]
-    public void floats(float value, double factor)
+    [Test]
+    public void Null() => new MultipleOfAttribute(0.1).IsValid(null).Should().BeTrue();
+
+    [Test]
+    public void empty_string() => new MultipleOfAttribute(0.1).IsValid(string.Empty).Should().BeTrue();
+
+    [TestCase(45, 5.000)]
+    [TestCase(45, 1.000)]
+    [TestCase(45, 0.100)]
+    [TestCase(45, 0.010)]
+    [TestCase(45, 0.001)]
+    public void shorts(short value, double factor)
+      => new MultipleOfAttribute(factor).IsValid(value).Should().BeTrue();
+
+    [TestCase(45, 5.000)]
+    [TestCase(45, 1.000)]
+    [TestCase(45, 0.100)]
+    [TestCase(45, 0.010)]
+    [TestCase(45, 0.001)]
+    public void ints(int value, double factor)
+       => new MultipleOfAttribute(factor).IsValid(value).Should().BeTrue();
+
+    [TestCase(45, 5.000)]
+    [TestCase(45, 1.000)]
+    [TestCase(45, 0.100)]
+    [TestCase(45, 0.010)]
+    [TestCase(45, 0.001)]
+    public void longs(long value, double factor)
         => new MultipleOfAttribute(factor).IsValid(value).Should().BeTrue();
 
     [TestCase("45.000", 5.000)]
@@ -52,34 +74,15 @@ public class Valid_for
     [TestCase("45.178%", 0.001)]
     public void percentages(Percentage value, double factor)
        => new MultipleOfAttribute(factor).IsValid(value).Should().BeTrue();
-
-    [TestCase(nameof(NonFloatingPoints))]
-    public void non_floating_points(object model)
-      => new MultipleOfAttribute(10).IsValid(model).Should().BeTrue();
-
-    static IEnumerable<object?> NonFloatingPoints()
-    {
-        yield return null;
-        yield return string.Empty;
-        yield return new[] { 42 };
-        yield return new object();
-    }
-}
-
-public class Initialization
-{
-    [Test]
-    public void has_sufficient_precision([Range(1, 23)]int decimals)
-    {
-        var factor = (decimal)Math.Pow(10, -decimals);
-        factor.Should().Be(Pow(-decimals));
-    }
-
-    private static decimal Pow(int decimals) => new(1, 0, 0, false, scale: (byte)-decimals);
 }
 
 public class Not_valid_for
 {
+    [TestCase(45, 06)]
+    [TestCase(45, 10)]
+    public void integers(long value, double factor)
+        => new MultipleOfAttribute(factor).IsValid(value).Should().BeFalse();
+
     [TestCase(float.NaN, 1)]
     [TestCase(float.NegativeInfinity, 1)]
     [TestCase(float.PositiveInfinity, 1)]
@@ -129,11 +132,35 @@ public class Not_valid_for
     [TestCase("45.178%", 0.01)]
     public void percentages(Percentage value, double factor)
        => new MultipleOfAttribute(factor).IsValid(value).Should().BeFalse();
+
+    [TestCase(nameof(NotSupportedTypes))]
+    public void not_supported_types(object model)
+    => new MultipleOfAttribute(10).IsValid(model).Should().BeFalse();
+
+    static IEnumerable<object?> NotSupportedTypes()
+    {
+        yield return true;
+        yield return 'C';
+        yield return new[] { 42 };
+        yield return new object();
+    }
+}
+
+public class Initialization
+{
+    [Test]
+    public void has_sufficient_precision([Range(1, 23)] int decimals)
+    {
+        var factor = (decimal)Math.Pow(10, -decimals);
+        factor.Should().Be(Pow(-decimals));
+    }
+
+    private static decimal Pow(int decimals) => new(1, 0, 0, false, scale: (byte)-decimals);
 }
 
 public class With_message
 {
-    [TestCase("nl", "De waarde van veld Total field is geen veelvoud van 0,001.")]
+    [TestCase("nl", "De waarde van veld Total is geen veelvoud van 0,001.")]
     [TestCase("en", "The value of the Total field is not a multiple of 0.001.")]
     public void culture_dependent(CultureInfo culture, string message)
     {

--- a/specs/Qowaiv.Validation.Specs/DataAnnotations/Attributes/Multiple_of_specs.cs
+++ b/specs/Qowaiv.Validation.Specs/DataAnnotations/Attributes/Multiple_of_specs.cs
@@ -1,0 +1,140 @@
+﻿using Qowaiv.Financial;
+using Qowaiv.Validation.DataAnnotations;
+
+namespace Data_Annotations.Attributes.Multiple_of_specs;
+
+public class Valid_for
+{
+    [TestCase("45.000", 5.000)]
+    [TestCase("45.000", 1.000)]
+    [TestCase("45.100", 0.100)]
+    [TestCase("45.170", 0.010)]
+    [TestCase("45.178", 0.001)]
+    public void floats(float value, double factor)
+        => new MultipleOfAttribute(factor).IsValid(value).Should().BeTrue();
+
+    [TestCase("45.000", 5.000)]
+    [TestCase("45.000", 1.000)]
+    [TestCase("45.100", 0.100)]
+    [TestCase("45.170", 0.010)]
+    [TestCase("45.178", 0.001)]
+    public void doubles(double value, double factor)
+        => new MultipleOfAttribute(factor).IsValid(value).Should().BeTrue();
+
+    [TestCase("45.000", 5.000)]
+    [TestCase("45.000", 1.000)]
+    [TestCase("45.100", 0.100)]
+    [TestCase("45.170", 0.010)]
+    [TestCase("45.178", 0.001)]
+    public void decimals(decimal value, double factor)
+        => new MultipleOfAttribute(factor).IsValid(value).Should().BeTrue();
+
+    [TestCase("45.000", 5.000)]
+    [TestCase("45.000", 1.000)]
+    [TestCase("45.100", 0.100)]
+    [TestCase("45.170", 0.010)]
+    [TestCase("45.178", 0.001)]
+    public void amounts(Amount value, double factor)
+        => new MultipleOfAttribute(factor).IsValid(value).Should().BeTrue();
+
+    [TestCase("EUR 45.000", 5.000)]
+    [TestCase("EUR 45.000", 1.000)]
+    [TestCase("EUR 45.100", 0.100)]
+    [TestCase("EUR 45.170", 0.010)]
+    [TestCase("EUR 45.178", 0.001)]
+    public void money(Money value, double factor)
+        => new MultipleOfAttribute(factor).IsValid(value).Should().BeTrue();
+
+    [TestCase("45.000%", 5.000)]
+    [TestCase("45.000%", 1.000)]
+    [TestCase("45.100%", 0.100)]
+    [TestCase("45.170%", 0.010)]
+    [TestCase("45.178%", 0.001)]
+    public void percentages(Percentage value, double factor)
+       => new MultipleOfAttribute(factor).IsValid(value).Should().BeTrue();
+
+    [TestCase(nameof(NonFloatingPoints))]
+    public void non_floating_points(object model)
+      => new MultipleOfAttribute(10).IsValid(model).Should().BeTrue();
+
+    static IEnumerable<object?> NonFloatingPoints()
+    {
+        yield return null;
+        yield return string.Empty;
+        yield return new[] { 42 };
+        yield return new object();
+    }
+}
+
+public class Not_valid_for
+{
+    [TestCase(float.NaN, 1)]
+    [TestCase(float.NegativeInfinity, 1)]
+    [TestCase(float.PositiveInfinity, 1)]
+    [TestCase(float.MinValue, 1)]
+    [TestCase(float.MaxValue, 1)]
+    [TestCase("45.500", 1.00)]
+    [TestCase("45.120", 0.10)]
+    [TestCase("45.178", 0.01)]
+    public void floats(float value, double factor)
+        => new MultipleOfAttribute(factor).IsValid(value).Should().BeFalse();
+
+    [TestCase(double.NaN, 1)]
+    [TestCase(double.NegativeInfinity, 1)]
+    [TestCase(double.PositiveInfinity, 1)]
+    [TestCase(double.MinValue, 1)]
+    [TestCase(double.MaxValue, 1)]
+    [TestCase("45.500", 1.00)]
+    [TestCase("45.120", 0.10)]
+    [TestCase("45.178", 0.01)]
+    public void doubles(double value, double factor)
+        => new MultipleOfAttribute(factor).IsValid(value).Should().BeFalse();
+
+    [TestCase("45.000", 6.00)]
+    [TestCase("45.500", 1.00)]
+    [TestCase("45.120", 0.10)]
+    [TestCase("45.178", 0.01)]
+    public void decimals(decimal value, double factor)
+        => new MultipleOfAttribute(factor).IsValid(value).Should().BeFalse();
+
+    [TestCase("45.000", 6.00)]
+    [TestCase("45.500", 1.00)]
+    [TestCase("45.120", 0.10)]
+    [TestCase("45.178", 0.01)]
+    public void amounts(Amount value, double factor)
+        => new MultipleOfAttribute(factor).IsValid(value).Should().BeFalse();
+
+    [TestCase("EUR 45.000", 6.00)]
+    [TestCase("EUR 45.500", 1.00)]
+    [TestCase("EUR 45.120", 0.10)]
+    [TestCase("EUR 45.178", 0.01)]
+    public void money(Money value, double factor)
+        => new MultipleOfAttribute(factor).IsValid(value).Should().BeFalse();
+
+    [TestCase("45.000%", 6.00)]
+    [TestCase("45.500%", 1.00)]
+    [TestCase("45.120%", 0.10)]
+    [TestCase("45.178%", 0.01)]
+    public void percentages(Percentage value, double factor)
+       => new MultipleOfAttribute(factor).IsValid(value).Should().BeFalse();
+}
+
+public class With_message
+{
+    [TestCase("nl", "De waarde van veld Total field is geen veelvoud van 0,001.")]
+    [TestCase("en", "The value of the Total field is not a multiple of 0.001.")]
+    public void culture_dependent(CultureInfo culture, string message)
+    {
+        using var _ = culture.Scoped();
+        new Model().Should().BeInvalidFor(new AnnotatedModelValidator<Model>())
+            .WithMessage(ValidationMessage.Error(message, "Total"));
+    }
+    internal class Model
+    {
+        [MultipleOf(0.001)]
+        public Amount Total { get; set; } = 0.12345.Amount();
+
+        [MultipleOf(0.001)]
+        public Amount Sub { get; set; } = 0.123.Amount();
+    }
+}

--- a/specs/Qowaiv.Validation.Specs/DataAnnotations/Attributes/Multiple_of_specs.cs
+++ b/specs/Qowaiv.Validation.Specs/DataAnnotations/Attributes/Multiple_of_specs.cs
@@ -146,7 +146,6 @@ public class Not_valid_for
         yield return new object();
         yield return new DateTime(2017, 06, 11, 06, 15, 00, DateTimeKind.Local);
         yield return DBNull.Value;
-
     }
 }
 

--- a/specs/Qowaiv.Validation.Specs/DataAnnotations/Attributes/Multiple_of_specs.cs
+++ b/specs/Qowaiv.Validation.Specs/DataAnnotations/Attributes/Multiple_of_specs.cs
@@ -66,6 +66,18 @@ public class Valid_for
     }
 }
 
+public class Initialization
+{
+    [Test]
+    public void has_sufficient_precision([Range(1, 23)]int decimals)
+    {
+        var factor = (decimal)Math.Pow(10, -decimals);
+        factor.Should().Be(Pow(-decimals));
+    }
+
+    private static decimal Pow(int decimals) => new(1, 0, 0, false, scale: (byte)-decimals);
+}
+
 public class Not_valid_for
 {
     [TestCase(float.NaN, 1)]
@@ -129,6 +141,7 @@ public class With_message
         new Model().Should().BeInvalidFor(new AnnotatedModelValidator<Model>())
             .WithMessage(ValidationMessage.Error(message, "Total"));
     }
+
     internal class Model
     {
         [MultipleOf(0.001)]

--- a/specs/Qowaiv.Validation.Specs/DataAnnotations/Attributes/Multiple_of_specs.cs
+++ b/specs/Qowaiv.Validation.Specs/DataAnnotations/Attributes/Multiple_of_specs.cs
@@ -133,16 +133,20 @@ public class Not_valid_for
     public void percentages(Percentage value, double factor)
        => new MultipleOfAttribute(factor).IsValid(value).Should().BeFalse();
 
-    [TestCase(nameof(NotSupportedTypes))]
+    [TestCaseSource(nameof(NotSupportedTypes))]
     public void not_supported_types(object model)
-    => new MultipleOfAttribute(10).IsValid(model).Should().BeFalse();
+        => new MultipleOfAttribute(10).IsValid(model).Should().BeFalse();
 
     static IEnumerable<object?> NotSupportedTypes()
     {
         yield return true;
+        yield return "Hello, World!";
         yield return 'C';
         yield return new[] { 42 };
         yield return new object();
+        yield return new DateTime(2017, 06, 11, 06, 15, 00, DateTimeKind.Local);
+        yield return DBNull.Value;
+
     }
 }
 

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/MandatoryAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/MandatoryAttribute.cs
@@ -23,7 +23,7 @@ public sealed class MandatoryAttribute : RequiredAttribute
     [Pure]
     protected override ValidationResult IsValid(object? value, ValidationContext validationContext)
         => IsValid(value, GetMemberType(Guard.NotNull(validationContext, nameof(validationContext))))
-        ? ValidationResult.Success
+        ? ValidationResult.Success!
         : ValidationMessage.Error(FormatErrorMessage(validationContext.DisplayName), validationContext.MemberNames());
 
     /// <summary>Gets the type of the field/property.</summary>

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/MandatoryAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/MandatoryAttribute.cs
@@ -22,19 +22,9 @@ public sealed class MandatoryAttribute : RequiredAttribute
     /// <inheritdoc />
     [Pure]
     protected override ValidationResult IsValid(object? value, ValidationContext validationContext)
-    {
-        Guard.NotNull(validationContext, nameof(validationContext));
-
-        if (IsValid(value, GetMemberType(validationContext)))
-        {
-            return ValidationResult.Success!;
-        }
-        else
-        {
-            var memberNames = validationContext.MemberName != null ? new[] { validationContext.MemberName } : Array.Empty<string>();
-            return ValidationMessage.Error(FormatErrorMessage(validationContext.DisplayName), memberNames);
-        }
-    }
+        => IsValid(value, GetMemberType(Guard.NotNull(validationContext, nameof(validationContext))))
+        ? ValidationResult.Success
+        : ValidationMessage.Error(FormatErrorMessage(validationContext.DisplayName), validationContext.MemberNames());
 
     /// <summary>Gets the type of the field/property.</summary>
     /// <remarks>
@@ -62,7 +52,7 @@ public sealed class MandatoryAttribute : RequiredAttribute
     [Pure]
     private bool IsValid(object? value, Type? memberType)
     {
-        if (value != null)
+        if (value is { })
         {
             var type = memberType ?? value.GetType();
             var underlyingType = QowaivType.GetNotNullableType(type);

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/MultipleOfAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/MultipleOfAttribute.cs
@@ -7,10 +7,6 @@ namespace Qowaiv.Validation.DataAnnotations;
 public sealed class MultipleOfAttribute : ValidationAttribute
 {
     /// <summary>Initializes a new instance of the <see cref="MultipleOfAttribute"/> class.</summary>
-    public MultipleOfAttribute(string factor)
-        : this(decimal.Parse(factor, CultureInfo.InvariantCulture)) { }
-
-    /// <summary>Initializes a new instance of the <see cref="MultipleOfAttribute"/> class.</summary>
     public MultipleOfAttribute(double factor)
         : this(AsDecimal(factor) ?? throw new ArgumentOutOfRangeException(nameof(factor), "Can not be represented by a decimal.")) { }
 
@@ -32,7 +28,7 @@ public sealed class MultipleOfAttribute : ValidationAttribute
     [Pure]
     protected override ValidationResult IsValid(object? value, ValidationContext validationContext)
         => IsValid(value)
-        ? ValidationResult.Success
+        ? ValidationResult.Success!
         : ValidationMessage.Error(FormatErrorMessage(validationContext.DisplayName), validationContext.MemberNames());
 
     /// <inheritdoc />

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/MultipleOfAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/MultipleOfAttribute.cs
@@ -40,13 +40,18 @@ public sealed class MultipleOfAttribute : ValidationAttribute
     [Pure]
     public override bool IsValid(object? value) => value switch
     {
+        null => true,
+        string str => string.IsNullOrEmpty(str),
+        bool => false,
+
         float flt => IsValid(flt),
         double dbl => IsValid(dbl),
         decimal dec => IsValid(dec),
         Amount amount => IsValid((decimal)amount),
         Money money => IsValid((decimal)money.Amount),
-        Percentage perentage => IsValid(100 * (decimal)perentage),
-        _ => true,
+        Percentage percentage => IsValid(100 * (decimal)percentage),
+        IConvertible convertible => IsValid(convertible),
+        _ => false,
     };
 
     [Pure]
@@ -63,6 +68,9 @@ public sealed class MultipleOfAttribute : ValidationAttribute
         => IsFinite(value)
         && AsDecimal(value) is { } dec
         && IsValid(dec);
+
+    [Pure]
+    private bool IsValid(IConvertible value) => IsValid(Convert.ToDecimal(value));
 
     [Pure]
     private static bool IsFinite(double value) => !double.IsNaN(value) && !double.IsInfinity(value);

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/MultipleOfAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/MultipleOfAttribute.cs
@@ -1,0 +1,44 @@
+﻿using Qowaiv.Financial;
+
+namespace Qowaiv.Validation.DataAnnotations.Attributes;
+
+/// <summary>Specifies that a field is a multiple of a factor.</summary>
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
+public class MultipleOfAttribute : ValidationAttribute
+{
+    /// <summary>Creates a new instance of the <see cref="MultipleOfAttribute"/> class.</summary>
+    public MultipleOfAttribute(double factor)
+    {
+        Factor = (decimal)factor;
+    }
+
+    /// <summary>The factor of which the value has to be a multiple of.</summary>
+    public decimal Factor { get;  }
+
+    /// <inheritdoc />
+    [Pure]
+    public override bool IsValid(object? value) => value switch
+    {
+        double dbl => IsValid(dbl),
+        decimal dec => IsValid(dec),
+        Amount amount => IsValid((decimal)amount),
+        Money money => IsValid((decimal)money.Amount),
+        Percentage perentage => IsValid(100 * (decimal)perentage),
+        _ => true,
+    };
+
+    [Pure]
+    private bool IsValid(decimal value) 
+        => value.RoundToMultiple(Factor) == value;
+
+    [Pure]
+    private bool IsValid(double value)
+        => !double.IsNaN(value)
+        && !double.IsInfinity(value)
+        && value >= decimal_MinValue
+        && value <= decimal_MaxValue
+        && IsValid((decimal)value);
+    
+    private const double decimal_MinValue = (double)decimal.MinValue;
+    private const double decimal_MaxValue = (double)decimal.MaxValue;
+}

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/MultipleOfAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/MultipleOfAttribute.cs
@@ -40,9 +40,9 @@ public sealed class MultipleOfAttribute : ValidationAttribute
     [Pure]
     public override bool IsValid(object? value) => value switch
     {
+        // should be handled by required.
         null => true,
         string str => string.IsNullOrEmpty(str),
-        bool => false,
 
         float flt => IsValid(flt),
         double dbl => IsValid(dbl),
@@ -51,6 +51,7 @@ public sealed class MultipleOfAttribute : ValidationAttribute
         Money money => IsValid((decimal)money.Amount),
         Percentage percentage => IsValid(100 * (decimal)percentage),
         IConvertible convertible => IsValid(convertible),
+
         _ => false,
     };
 
@@ -70,7 +71,14 @@ public sealed class MultipleOfAttribute : ValidationAttribute
         && IsValid(dec);
 
     [Pure]
-    private bool IsValid(IConvertible value) => IsValid(Convert.ToDecimal(value));
+    private bool IsValid(IConvertible value)
+        => IsValid(value.GetTypeCode()) 
+        && IsValid(Convert.ToDecimal(value));
+
+    [Pure]
+    private bool IsValid(TypeCode type)
+        => type >= TypeCode.SByte 
+        && type <= TypeCode.UInt64;
 
     [Pure]
     private static bool IsFinite(double value) => !double.IsNaN(value) && !double.IsInfinity(value);

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/MultipleOfAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/MultipleOfAttribute.cs
@@ -1,24 +1,50 @@
 ﻿using Qowaiv.Financial;
 
-namespace Qowaiv.Validation.DataAnnotations.Attributes;
+namespace Qowaiv.Validation.DataAnnotations;
 
 /// <summary>Specifies that a field is a multiple of a factor.</summary>
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
-public class MultipleOfAttribute : ValidationAttribute
+public sealed class MultipleOfAttribute : ValidationAttribute
 {
-    /// <summary>Creates a new instance of the <see cref="MultipleOfAttribute"/> class.</summary>
+    /// <summary>Initializes a new instance of the <see cref="MultipleOfAttribute"/> class.</summary>
+    public MultipleOfAttribute(string factor)
+        : this(decimal.Parse(factor, CultureInfo.InvariantCulture)) { }
+
+    /// <summary>Initializes a new instance of the <see cref="MultipleOfAttribute"/> class.</summary>
     public MultipleOfAttribute(double factor)
+        : this(AsDecimal(factor) ?? throw new ArgumentOutOfRangeException(nameof(factor), "Can not be represented by a decimal.")) { }
+
+    /// <summary>Initializes a new instance of the <see cref="MultipleOfAttribute"/> class.</summary>
+    private MultipleOfAttribute(decimal factor)
     {
-        Factor = (decimal)factor;
+        Factor = factor;
+        ErrorMessageResourceType = typeof(QowaivValidationMessages);
+        ErrorMessageResourceName = nameof(QowaivValidationMessages.MultipleOfAttribute_ValidationError);
     }
 
     /// <summary>The factor of which the value has to be a multiple of.</summary>
-    public decimal Factor { get;  }
+    public decimal Factor { get; }
+
+    /// <inheritdoc />
+    public override bool RequiresValidationContext => true;
+
+    /// <inheritdoc />
+    [Pure]
+    protected override ValidationResult IsValid(object? value, ValidationContext validationContext)
+        => IsValid(value)
+        ? ValidationResult.Success
+        : ValidationMessage.Error(FormatErrorMessage(validationContext.DisplayName), validationContext.MemberNames());
+
+    /// <inheritdoc />
+    [Pure]
+    public override string FormatErrorMessage(string? name)
+        => string.Format(CultureInfo.CurrentCulture, ErrorMessageString, name, Factor);
 
     /// <inheritdoc />
     [Pure]
     public override bool IsValid(object? value) => value switch
     {
+        float flt => IsValid(flt),
         double dbl => IsValid(dbl),
         decimal dec => IsValid(dec),
         Amount amount => IsValid((decimal)amount),
@@ -28,17 +54,37 @@ public class MultipleOfAttribute : ValidationAttribute
     };
 
     [Pure]
-    private bool IsValid(decimal value) 
-        => value.RoundToMultiple(Factor) == value;
+    private bool IsValid(decimal value) => value % Factor == 0;
+
+    [Pure]
+    private bool IsValid(float value)
+       => IsFinite(value)
+       && AsDecimal(value) is { } dec
+       && IsValid(dec);
 
     [Pure]
     private bool IsValid(double value)
-        => !double.IsNaN(value)
-        && !double.IsInfinity(value)
-        && value >= decimal_MinValue
-        && value <= decimal_MaxValue
-        && IsValid((decimal)value);
-    
-    private const double decimal_MinValue = (double)decimal.MinValue;
-    private const double decimal_MaxValue = (double)decimal.MaxValue;
+        => IsFinite(value)
+        && AsDecimal(value) is { } dec
+        && IsValid(dec);
+
+    [Pure]
+    private static bool IsFinite(double value) => !double.IsNaN(value) && !double.IsInfinity(value);
+
+    [Pure]
+    private static decimal? AsDecimal(float value)
+        => value >= Decimal_MinValue
+        && value <= Decimal_MaxValue
+            ? (decimal)value
+            : null;
+
+    [Pure]
+    private static decimal? AsDecimal(double value)
+        => value >= Decimal_MinValue
+        && value <= Decimal_MaxValue
+            ? (decimal)value
+            : null;
+
+    private const double Decimal_MinValue = (double)decimal.MinValue;
+    private const double Decimal_MaxValue = (double)decimal.MaxValue;
 }

--- a/src/Qowaiv.Validation.DataAnnotations/Extensions/System.ComponentModel.DataAnnotations.ValidationContextExtensions.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Extensions/System.ComponentModel.DataAnnotations.ValidationContextExtensions.cs
@@ -7,4 +7,11 @@ public static class ValidationContextExtensions
     [Pure]
     public static T? GetSevice<T>(this ValidationContext validationContext)
         => (T?)Guard.NotNull(validationContext, nameof(validationContext)).GetService(typeof(T));
+
+    /// <summary>Gets the <see cref="ValidationContext.MemberName"/> as an array.</summary>
+    [Pure]
+    internal static string[] MemberNames(this ValidationContext? validationContext)
+        => validationContext?.MemberName is { }
+        ? new[] { validationContext.MemberName }
+        : Array.Empty<string>();
 }

--- a/src/Qowaiv.Validation.DataAnnotations/Qowaiv.Validation.DataAnnotations.csproj
+++ b/src/Qowaiv.Validation.DataAnnotations/Qowaiv.Validation.DataAnnotations.csproj
@@ -4,10 +4,13 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net5.0;net6.0;net7.0</TargetFrameworks>
-    <Version>1.3.0</Version>
+    <Version>1.4.0</Version>
     <PackageReleaseNotes>
 ToBeReleased
 - Marked [NestedModel] attribute as obsolete. #70
+v1.4.0
+- Introduced [MultipleOf] validation attribute.
+- Marked [NestedModel] attribute as obsolete.
 v1.3.0
 - Support .NET 7.0. #62
 v1.0.1
@@ -36,8 +39,11 @@ v0.0.4
     </PackageReleaseNotes>
   </PropertyGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'" >
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0"/>
+  </ItemGroup>
+
   <ItemGroup>
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" Condition="'$(TargetFramework)'=='netstandard2.0'" />
     <PackageReference Include="Qowaiv" Version="6.0.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>

--- a/src/Qowaiv.Validation.DataAnnotations/Qowaiv.Validation.DataAnnotations.csproj
+++ b/src/Qowaiv.Validation.DataAnnotations/Qowaiv.Validation.DataAnnotations.csproj
@@ -6,11 +6,9 @@
     <TargetFrameworks>netstandard2.0;net5.0;net6.0;net7.0</TargetFrameworks>
     <Version>1.4.0</Version>
     <PackageReleaseNotes>
-ToBeReleased
-- Marked [NestedModel] attribute as obsolete. #70
 v1.4.0
-- Introduced [MultipleOf] validation attribute.
-- Marked [NestedModel] attribute as obsolete.
+- Introduced [MultipleOf] validation attribute. #69
+- Marked [NestedModel] attribute as obsolete. #70
 v1.3.0
 - Support .NET 7.0. #62
 v1.0.1

--- a/src/Qowaiv.Validation.DataAnnotations/Qowaiv.Validation.DataAnnotations.csproj
+++ b/src/Qowaiv.Validation.DataAnnotations/Qowaiv.Validation.DataAnnotations.csproj
@@ -66,9 +66,7 @@ v0.0.4
   </ItemGroup>
 
   <ItemGroup>
-    <EmbeddedResource Update="QowaivValidationMessages.nl.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-    </EmbeddedResource>
+    <EmbeddedResource Update="QowaivValidationMessages.nl.resx" />
     <EmbeddedResource Update="QowaivValidationMessages.resx">
       <LastGenOutput>QowaivValidationMessages.Designer.cs</LastGenOutput>
       <Generator>ResXFileCodeGenerator</Generator>

--- a/src/Qowaiv.Validation.DataAnnotations/QowaivValidationMessages.Designer.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/QowaivValidationMessages.Designer.cs
@@ -88,15 +88,6 @@ namespace Qowaiv.Validation.DataAnnotations {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The {0} model can not be operated on as it is invalid..
-        /// </summary>
-        internal static string InvalidModelException {
-            get {
-                return ResourceManager.GetString("InvalidModelException", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to The {0} field is required..
         /// </summary>
         internal static string MandatoryAttribute_ValidationError {
@@ -106,29 +97,11 @@ namespace Qowaiv.Validation.DataAnnotations {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The postal code {0} is not valid for {1}..
+        ///   Looks up a localized string similar to The value of the {0} field is not a multiple of {1}..
         /// </summary>
-        internal static string PostalCodeValidator_ErrorMessage {
+        internal static string MultipleOfAttribute_ValidationError {
             get {
-                return ResourceManager.GetString("PostalCodeValidator_ErrorMessage", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The property &apos;{1}&apos; on resource type &apos;{0}&apos; is not a string type..
-        /// </summary>
-        internal static string ValidationRule_ResourcePropertyNotStringType {
-            get {
-                return ResourceManager.GetString("ValidationRule_ResourcePropertyNotStringType", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The resource type &apos;{0}&apos; does not have an accessible static property named &apos;{1}&apos;..
-        /// </summary>
-        internal static string ValidationRule_ResourceTypeDoesNotHaveProperty {
-            get {
-                return ResourceManager.GetString("ValidationRule_ResourceTypeDoesNotHaveProperty", resourceCulture);
+                return ResourceManager.GetString("MultipleOfAttribute_ValidationError", resourceCulture);
             }
         }
     }

--- a/src/Qowaiv.Validation.DataAnnotations/QowaivValidationMessages.nl.resx
+++ b/src/Qowaiv.Validation.DataAnnotations/QowaivValidationMessages.nl.resx
@@ -19,6 +19,6 @@
     <value>Het veld {0} is verplicht.</value>
   </data>
   <data name="MultipleOfAttribute_ValidationError" xml:space="preserve">
-    <value>De waarde van veld {0} field is geen veelvoud van {1}.</value>
+    <value>De waarde van veld {0} is geen veelvoud van {1}.</value>
   </data>
 </root>

--- a/src/Qowaiv.Validation.DataAnnotations/QowaivValidationMessages.nl.resx
+++ b/src/Qowaiv.Validation.DataAnnotations/QowaivValidationMessages.nl.resx
@@ -3,14 +3,11 @@
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
   </resheader>
-  <resheader name="version">
-    <value>2.0</value>
-  </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms</value>
   </resheader>
   <data name="AllowedValuesAttribute_ValidationError" xml:space="preserve">
     <value>De waarde van het veld {0} is niet toegestaan.</value>
@@ -21,7 +18,7 @@
   <data name="MandatoryAttribute_ValidationError" xml:space="preserve">
     <value>Het veld {0} is verplicht.</value>
   </data>
-  <data name="PostalCodeValidator_ErrorMessage" xml:space="preserve">
-    <value>De postcode {0} is niet geldig voor {1}.</value>
+  <data name="MultipleOfAttribute_ValidationError" xml:space="preserve">
+    <value>De waarde van veld {0} field is geen veelvoud van {1}.</value>
   </data>
 </root>

--- a/src/Qowaiv.Validation.DataAnnotations/QowaivValidationMessages.nl.resx
+++ b/src/Qowaiv.Validation.DataAnnotations/QowaivValidationMessages.nl.resx
@@ -4,10 +4,10 @@
     <value>text/microsoft-resx</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms</value>
+    <value>System.Resources.ResXResourceReader</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms</value>
+    <value>System.Resources.ResXResourceWriter</value>
   </resheader>
   <data name="AllowedValuesAttribute_ValidationError" xml:space="preserve">
     <value>De waarde van het veld {0} is niet toegestaan.</value>

--- a/src/Qowaiv.Validation.DataAnnotations/QowaivValidationMessages.resx
+++ b/src/Qowaiv.Validation.DataAnnotations/QowaivValidationMessages.resx
@@ -4,10 +4,10 @@
     <value>text/microsoft-resx</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms</value>
+    <value>System.Resources.ResXResourceReader</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms</value>
+    <value>System.Resources.ResXResourceWriter</value>
   </resheader>
   <data name="AllowedValuesAttribute_ValidationError" xml:space="preserve">
     <value>The value of the {0} field is not allowed.</value>

--- a/src/Qowaiv.Validation.DataAnnotations/QowaivValidationMessages.resx
+++ b/src/Qowaiv.Validation.DataAnnotations/QowaivValidationMessages.resx
@@ -1,16 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <resheader name="resmimetype">
+   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
   </resheader>
-  <resheader name="version">
-    <value>2.0</value>
-  </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms</value>
   </resheader>
   <data name="AllowedValuesAttribute_ValidationError" xml:space="preserve">
     <value>The value of the {0} field is not allowed.</value>
@@ -21,19 +18,10 @@
   <data name="DistinctValuesAttribute_ValidationError" xml:space="preserve">
     <value>All values of the {0} field should be distinct.</value>
   </data>
-  <data name="InvalidModelException" xml:space="preserve">
-    <value>The {0} model can not be operated on as it is invalid.</value>
-  </data>
   <data name="MandatoryAttribute_ValidationError" xml:space="preserve">
     <value>The {0} field is required.</value>
   </data>
-  <data name="PostalCodeValidator_ErrorMessage" xml:space="preserve">
-    <value>The postal code {0} is not valid for {1}.</value>
-  </data>
-  <data name="ValidationRule_ResourcePropertyNotStringType" xml:space="preserve">
-    <value>The property '{1}' on resource type '{0}' is not a string type.</value>
-  </data>
-  <data name="ValidationRule_ResourceTypeDoesNotHaveProperty" xml:space="preserve">
-    <value>The resource type '{0}' does not have an accessible static property named '{1}'.</value>
+  <data name="MultipleOfAttribute_ValidationError" xml:space="preserve">
+    <value>The value of the {0} field is not a multiple of {1}.</value>
   </data>
 </root>

--- a/src/Qowaiv.Validation.DataAnnotations/README.md
+++ b/src/Qowaiv.Validation.DataAnnotations/README.md
@@ -104,3 +104,25 @@ public class Model
     public IEnumerable<int> Numbers { get; set; }
 }
 ```
+
+### Multiple of
+The `[MultipleOf]` attribute validates that the value of a field is a multiple
+of the specified factor..
+
+``` C#
+public class Model
+{
+    [MultipleOf(0.001)]
+    public Amount Total { get; set; }
+}
+```
+### Optional 
+The `[Optional]` attribute indicates explicitly that a field is optional.
+
+``` C#
+public class Model
+{
+    [Optional]
+    public string? Message { get; set; }
+}
+```

--- a/src/Qowaiv.Validation.DataAnnotations/README.md
+++ b/src/Qowaiv.Validation.DataAnnotations/README.md
@@ -14,7 +14,7 @@ Result<SomeModel> result = validator.Validate(model);
 ## Validation messages
 `Qowaiv.Validation.DataAnnotations.ValidationMessage` inherits Microsoft's
 `ValidationResult`, and implements `Qowaiv.Validation.Abstractions.IValidationMessage`.
-This allows the creates messages with different severities:
+This allows the creation of messages with different severities:
 
 ``` C#
 var none = ValidationMessage.None;
@@ -45,7 +45,7 @@ public class Model
 
 ### Any
 The `[Required]` attribute does not work (well) for collections. The `[Any]`
-attribute does. It is only valid as he collection contains at least one item.
+attribute does. It is only valid if the collection contains at least one item.
 
 ``` C#
 public class Model
@@ -56,7 +56,7 @@ public class Model
 ```
 
 ### Allowed values
-The `]AllowedValues]` attribute allows to define a subset of allowed values. It
+The `[AllowedValues]` attribute allows to define a subset of allowed values. It
 supports type converters to get the allowed values based on a string value.
 
 ``` C#

--- a/src/Qowaiv.Validation.DataAnnotations/README.md
+++ b/src/Qowaiv.Validation.DataAnnotations/README.md
@@ -1,1 +1,106 @@
-﻿# Qowaiv Validation
+﻿# Qowaiv DataAnnotations based validation
+Provides an data annotations based implementation of the `Qowaiv.Validation.Abstractions.IValidator`
+and data annotation attributes.
+
+## Annotated model validator
+The `AnnotatedModelValidator` validates a model using its data annotations.
+It returns a `Result<TModel>` of the validated model:
+
+``` C#
+var validator = new AnnotatedModelValidator<SomeModel>();
+Result<SomeModel> result = validator.Validate(model);
+```
+
+## Validation messages
+`Qowaiv.Validation.DataAnnotations.ValidationMessage` inherits Microsoft's
+`ValidationResult`, and implements `Qowaiv.Validation.Abstractions.IValidationMessage`.
+This allows the creates messages with different severities:
+
+``` C#
+var none = ValidationMessage.None;
+var info = ValidationMessage.Info(message, args);
+var warn = ValidationMessage.Warning(message, args);
+var error = ValidationMessage.Error(message, args);
+```
+
+## Validation attributes
+Multiple `[System.ComponentModel.DataAnnotations.Validation]` attributes can be
+used to decorate models.
+
+### Mandatory
+The `[Required]` attribute does not work for value types. The `[Mandatory]`
+attribute does. The default value of the `struct` is not valid. It also is not
+valid for the Unknown value, unless that is explicitly allowed.
+
+``` C#
+public class Model
+{
+    [Mandatory(AllowUnknownValue = true)]
+    public EmailAddress Email { get; set; }
+
+    [Mandatory()]
+    public string SomeString { get; set; }
+}
+```
+
+### Any
+The `[Required]` attribute does not work (well) for collections. The `[Any]`
+attribute does. It is only valid as he collection contains at least one item.
+
+``` C#
+public class Model
+{
+    [Any()]
+    public List<int> Numbers { get; set; }
+}
+```
+
+### Allowed values
+The `]AllowedValues]` attribute allows to define a subset of allowed values. It
+supports type converters to get the allowed values based on a string value.
+
+``` C#
+public class Model
+{
+    [AllowedValues("DE", "FR", "GB")]
+    public Country CountryOfBirth { get; set; }
+}
+```
+
+### Forbidden values
+The `[ForbiddenValues]` attribute allows to define a subset of forbidden values. It
+supports type converters to get the allowed values based on a string value.
+
+``` C#
+public class Model
+{
+    [ForbiddenValues("US", "IR")]
+    public Country CountryOfBirth { get; set; }
+}
+```
+
+### Defined enum values only
+The `[DefinedEnumValuesOnly]` attribute limits the allowed values to defined
+enums only. By default it supports all possible combinations of defined enums 
+when dealing with flags, but that can be restricted by setting 
+`OnlyAllowDefinedFlagsCombinations` to true.
+
+``` C#
+public class Model
+{
+    [DefinedEnumValuesOnly(OnlyAllowDefinedFlagsCombinations = false)]
+    public SomeEnum CountryOfBirth { get; set; }
+}
+```
+
+### Distinct values
+The `[DistinctValues]` attribute validates that all items of the collection are
+distinct. If needed, a custom `IEqualityComparer` comparer can be defined.
+
+``` C#
+public class Model
+{
+    [DistinctValues(typeof(CustomEqualityComparer))]
+    public IEnumerable<int> Numbers { get; set; }
+}
+```

--- a/src/Qowaiv.Validation.DataAnnotations/README.md
+++ b/src/Qowaiv.Validation.DataAnnotations/README.md
@@ -69,7 +69,7 @@ public class Model
 
 ### Forbidden values
 The `[ForbiddenValues]` attribute allows to define a subset of forbidden values. It
-supports type converters to get the allowed values based on a string value.
+supports type converters to get the forbidden values based on a string value.
 
 ``` C#
 public class Model


### PR DESCRIPTION
One of the constraints that can be defined in Open API models is `mutlipleof`. To generate models that fully support that concept, a `[MultipleOf]` attribute comes in handy.