### PR TITLE
Add validation to validate that floating points are finite numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,86 +181,8 @@ for communicating that a service was unavailable. A use case for this can be to
 communicate a `503 - Service Unavailable` response.
 
 ## Qowaiv exensions on [*Fluent Validation](https://fluentvalidation.net/)
-
-### Validators
-
-#### Not unknown
-The `UnknownValidation` validates that a value does not equal the Unknown
-value (if existing of course). Accessible via the fluent syntax.
-
-``` C#
-public class CustomValidator : AbstractValidator<Model>
-{
-    public CustomValidator()
-    {
-        RuleFor(m => m.Email).NotEmptyOrUnknown();
-        RuleFor(m => m.Iban).NotUnknown();
-    }
-}
-```
-
-#### Required
-The `RequiredValidation` validates that a required property has a set value. If
-specified, an unknown value can be seen as a set value, by default it is not.
-
-``` C#
-public class CustomValidator : AbstractValidator<Model>
-{
-    public CustomValidator()
-    {
-        RuleFor(m => m.Email).Required();
-        RuleFor(m => m.Iban).Required(allowUnknown: true);
-    }
-}
-```
-
-### relative to the clock
-
-The `ClockValidation` validates if a date (time) is in the past, or future.
-It supports `Date`, `DateTime`, `Date?`, and `DateTime?`, and the provision
-of custom date (time) provider. By Default, `Clock.Now()` and `Clock.Today()`
-are used.
-
-``` C#
-public class CustomValidator : AbstractValidator<Model>
-{
-    public CustomValidator()
-    {
-        RuleFor(m => m.Date1).InFuture();
-        RuleFor(m => m.Date2).InPast();
-        RuleFor(m => m.Date3).NotInFuture();
-        RuleFor(m => m.Date4).NotInPast(() => CustomeDateProvider());
-    }
-}
-```
-
-#### Email address should be IP-based
-The `EmailAddressValidation` validates that an `EmailAddress`
-does not have an IP-based domain.
-
-``` C#
-public class CustomValidator : AbstractValidator<Model>
-{
-    public CustomValidator()
-    {
-        RuleFor(m => m.Email).NotIPBased();
-    }
-}
-```
-
-#### PostalCode valid for specific country
-The `PostalCodeValidation` validates that a `PostalCode` value is valid for
-a specific `Country`, both static and via another property.
-
-``` C#
-public class CustomValidator : AbstractValidator<Model>
-{
-    public CustomValidator()
-    {
-        RuleFor(m => m.PostalCode).ValidFor(m => m.Country);
-    }
-}
-```
+Provides a Fluent Valdation based implentation of the `Qowaiv.Validation.Abstractions.IValidator`
+and custom validation extensions [(..)](src/Qowaiv.Validation.Fluent/README.md).
 
 ## Qowaiv DataAnnotations based validation
 Provides an data annotations based implementation of the `Qowaiv.Validation.Abstractions.IValidator`

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ for communicating that a service was unavailable. A use case for this can be to
 communicate a `503 - Service Unavailable` response.
 
 ## Qowaiv exensions on [*Fluent Validation](https://fluentvalidation.net/)
-Provides a Fluent Valdation based implentation of the `Qowaiv.Validation.Abstractions.IValidator`
+Provides a Fluent Validation based implementation of the `Qowaiv.Validation.Abstractions.IValidator`
 and custom validation extensions [(..)](src/Qowaiv.Validation.Fluent/README.md).
 
 ## Qowaiv DataAnnotations based validation

--- a/specs/Qowaiv.Validation.Specs/DataAnnotations/Attributes/Is_finite_specs.cs
+++ b/specs/Qowaiv.Validation.Specs/DataAnnotations/Attributes/Is_finite_specs.cs
@@ -1,0 +1,59 @@
+﻿using Qowaiv.Validation.DataAnnotations;
+
+namespace Data_annotations.Attributes.Is_finite_specs;
+
+public class Is_valid_for
+{
+    [Test]
+    public void Null() => new IsFiniteAttribute().IsValid(null).Should().BeTrue();
+
+    [TestCase(double.MinValue)]
+    [TestCase(0.33)]
+    [TestCase(0.0)]
+    [TestCase(42.0)]
+    [TestCase(double.MaxValue)]
+    [TestCase(float.MinValue)]
+    [TestCase(0.33f)]
+    [TestCase(0.0f)]
+    [TestCase(42.0f)]
+    [TestCase(float.MaxValue)]
+    public void finite_floating_points(object value)
+        => new IsFiniteAttribute().IsValid(value).Should().BeTrue();
+}
+
+public class Is_invalid_for
+{
+    [TestCase(float.NaN)]
+    [TestCase(float.NegativeInfinity)]
+    [TestCase(float.PositiveInfinity)]
+    [TestCase(double.NaN)]
+    [TestCase(double.NegativeInfinity)]
+    [TestCase(double.PositiveInfinity)]
+    public void not_finate(object value)
+        => new IsFiniteAttribute().IsValid(value).Should().BeFalse();
+
+    [TestCase("Hello")]
+    [TestCase(42)]
+    [TestCase(128L)]
+    [TestCase(1024UL)]
+    public void non_floating_poitns(object value)
+       => new IsFiniteAttribute().IsValid(value).Should().BeFalse();
+}
+public class With_message
+{
+    [TestCase("nl", "De waarde van het Total veld is geen eindig getal.")]
+    [TestCase("en", "The value of the Total field is not a finate number.")]
+    public void culture_dependent(CultureInfo culture, string message)
+    {
+        using var _ = culture.Scoped();
+        new Model().Should().BeInvalidFor(new AnnotatedModelValidator<Model>())
+            .WithMessage(ValidationMessage.Error(message, "Total"));
+    }
+
+    internal class Model
+    {
+        [IsFinite]
+        public double Total { get; set; } = double.NaN;
+    }
+}
+

--- a/specs/Qowaiv.Validation.Specs/DataAnnotations/Attributes/Is_finite_specs.cs
+++ b/specs/Qowaiv.Validation.Specs/DataAnnotations/Attributes/Is_finite_specs.cs
@@ -29,20 +29,20 @@ public class Is_invalid_for
     [TestCase(double.NaN)]
     [TestCase(double.NegativeInfinity)]
     [TestCase(double.PositiveInfinity)]
-    public void not_finate(object value)
+    public void not_finite(object value)
         => new IsFiniteAttribute().IsValid(value).Should().BeFalse();
 
     [TestCase("Hello")]
     [TestCase(42)]
     [TestCase(128L)]
     [TestCase(1024UL)]
-    public void non_floating_poitns(object value)
+    public void non_floating_points(object value)
        => new IsFiniteAttribute().IsValid(value).Should().BeFalse();
 }
 public class With_message
 {
     [TestCase("nl", "De waarde van het Total veld is geen eindig getal.")]
-    [TestCase("en", "The value of the Total field is not a finate number.")]
+    [TestCase("en", "The value of the Total field is not a finite number.")]
     public void culture_dependent(CultureInfo culture, string message)
     {
         using var _ = culture.Scoped();

--- a/specs/Qowaiv.Validation.Specs/DataAnnotations/Attributes/Multiple_of_specs.cs
+++ b/specs/Qowaiv.Validation.Specs/DataAnnotations/Attributes/Multiple_of_specs.cs
@@ -8,9 +8,6 @@ public class Valid_for
     [Test]
     public void Null() => new MultipleOfAttribute(0.1).IsValid(null).Should().BeTrue();
 
-    [Test]
-    public void empty_string() => new MultipleOfAttribute(0.1).IsValid(string.Empty).Should().BeTrue();
-
     [TestCase(45, 5.000)]
     [TestCase(45, 1.000)]
     [TestCase(45, 0.100)]

--- a/specs/Qowaiv.Validation.Specs/Fluent/Models/FloatingPointsModel.cs
+++ b/specs/Qowaiv.Validation.Specs/Fluent/Models/FloatingPointsModel.cs
@@ -1,0 +1,24 @@
+﻿using FluentValidation;
+using Qowaiv.Validation.Fluent;
+
+namespace Specs.Fluent.Models;
+
+public sealed class FloatingPointsModel
+{
+    public float Float { get; set; }
+    public double Double { get; set; }
+
+    public float? NullableFloat { get; set; }
+    public double? NullableDouble { get; set; }
+}
+
+public sealed class FloatingPointsValidator : ModelValidator<FloatingPointsModel>
+{
+    public FloatingPointsValidator()
+    {
+        RuleFor(m => m.Double).IsFinite();
+        RuleFor(m => m.Float).IsFinite();
+        RuleFor(m => m.NullableFloat).IsFinite();
+        RuleFor(m => m.NullableDouble).IsFinite();
+    }
+}

--- a/specs/Qowaiv.Validation.Specs/Fluent/Validators/Is_finite_specs.cs
+++ b/specs/Qowaiv.Validation.Specs/Fluent/Validators/Is_finite_specs.cs
@@ -1,0 +1,96 @@
+﻿using Qowaiv.Validation.Fluent;
+using Specs.Fluent.Models;
+
+namespace Fluent_validation.Is_finite_specs;
+
+public class Valid_for
+{
+    [TestCase(double.MinValue)]
+    [TestCase(0.33)]
+    [TestCase(0)]
+    [TestCase(42)]
+    [TestCase(double.MaxValue)]
+    public void finite_doubles(double value)
+        => new FloatingPointsModel { Double = value }
+        .Should().BeValidFor(new FloatingPointsValidator());
+
+    [TestCase(double.MinValue)]
+    [TestCase(0.33f)]
+    [TestCase(0)]
+    [TestCase(42)]
+    [TestCase(double.MaxValue)]
+    public void finite_nullable_doubles(double value)
+       => new FloatingPointsModel { NullableDouble = value }
+       .Should().BeValidFor(new FloatingPointsValidator());
+
+    [TestCase(float.MinValue)]
+    [TestCase(0.33f)]
+    [TestCase(0)]
+    [TestCase(42)]
+    [TestCase(float.MaxValue)]
+    public void finite_floats(float value)
+        => new FloatingPointsModel { Float = value }
+        .Should().BeValidFor(new FloatingPointsValidator());
+
+    [TestCase(float.MinValue)]
+    [TestCase(0.33f)]
+    [TestCase(0)]
+    [TestCase(42)]
+    [TestCase(float.MaxValue)]
+    public void finite_nullable_floats(float value)
+       => new FloatingPointsModel { NullableFloat = value }
+       .Should().BeValidFor(new FloatingPointsValidator());
+
+    [Test]
+    public void not_set_nullable_double()
+        => new FloatingPointsModel { NullableFloat = null }
+        .Should().BeValidFor(new FloatingPointsValidator());
+
+    [Test]
+    public void not_set_nullable_float()
+       => new FloatingPointsModel { NullableFloat = null }
+       .Should().BeValidFor(new FloatingPointsValidator());
+}
+
+public class Invalid_for
+{
+    [TestCase(double.NaN)]
+    [TestCase(double.NegativeInfinity)]
+    [TestCase(double.PositiveInfinity)]
+    public void not_finite_doubles(double value)
+    {
+        using var _ = CultureInfo.InvariantCulture.Scoped();
+
+        new FloatingPointsModel { Double = value, NullableDouble = value }
+            .Should().BeInvalidFor(new FloatingPointsValidator())
+            .WithMessages(
+                ValidationMessage.Error("'Double' must be a finite number.", "Double"),
+                ValidationMessage.Error("'Nullable Double' must be a finite number.", "NullableDouble"));
+    }
+
+    [TestCase(float.NaN)]
+    [TestCase(float.NegativeInfinity)]
+    [TestCase(float.PositiveInfinity)]
+    public void not_finite_floats(float value)
+    {
+        using var _ = CultureInfo.InvariantCulture.Scoped();
+
+        new FloatingPointsModel { Float = value, NullableFloat = value }
+            .Should().BeInvalidFor(new FloatingPointsValidator())
+            .WithMessages(
+                ValidationMessage.Error("'Float' must be a finite number.", "Float"),
+                ValidationMessage.Error("'Nullable Float' must be a finite number.", "NullableFloat"));
+    }
+
+    [TestCase("nl", "'Double' moet een eindig getal zijn.")]
+    [TestCase("en", "'Double' must be a finite number.")]
+    public void with_localized_message(CultureInfo culture, string message)
+    {
+        using var _ = culture.Scoped();
+
+        new FloatingPointsModel { Double = double.NaN }
+            .Should().BeInvalidFor(new FloatingPointsValidator())
+            .WithMessage(
+                ValidationMessage.Error(message, "Double"));
+    }
+}

--- a/specs/Qowaiv.Validation.Specs/Qowaiv.Validation.Specs.csproj
+++ b/specs/Qowaiv.Validation.Specs/Qowaiv.Validation.Specs.csproj
@@ -22,6 +22,7 @@
   </ItemGroup>
 
   <ItemGroup Label="Depedencies">
+    <PackageReference Include="FluentValidation" Version="11.*" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.*" />
     <PackageReference Include="Qowaiv" Version="6.*" />
   </ItemGroup>

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/IsFiniteAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/IsFiniteAttribute.cs
@@ -1,0 +1,24 @@
+﻿namespace Qowaiv.Validation.DataAnnotations;
+
+/// <summary>Specifies that a field is a finite number.</summary>
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
+public sealed class IsFiniteAttribute : ValidationAttribute
+{
+    /// <summary>Initializes a new instance of the <see cref="IsFiniteAttribute"/> class.</summary>
+    public IsFiniteAttribute()
+    {
+        ErrorMessageResourceType = typeof(QowaivValidationMessages);
+        ErrorMessageResourceName = nameof(QowaivValidationMessages.IsFiniteAttribute_ValidationError);
+    }
+
+    /// <inheritdoc />
+    [Pure]
+    public override bool IsValid(object? value)
+        => value is null
+        || value switch
+        {
+            float flt => flt.IsFinite(),
+            double dbl => dbl.IsFinite(),
+            _ => false,
+        };
+}

--- a/src/Qowaiv.Validation.DataAnnotations/Extensions/System.FloatingPoints.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Extensions/System.FloatingPoints.cs
@@ -1,0 +1,20 @@
+﻿namespace System;
+
+internal static class FloatingPointExtensions
+{
+    [Pure]
+    public static bool IsFinite(this double d)
+#if NETSTANDARD
+        => !double.IsNaN(d) && !double.IsInfinity(d);
+#else
+        => double.IsFinite(d);
+#endif
+
+    [Pure]
+    public static bool IsFinite(this float f)
+#if NETSTANDARD
+    => !float.IsNaN(f) && !float.IsInfinity(f);
+#else
+        => float.IsFinite(f);
+#endif
+}

--- a/src/Qowaiv.Validation.DataAnnotations/Extensions/System.FloatingPoints.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Extensions/System.FloatingPoints.cs
@@ -13,7 +13,7 @@ internal static class FloatingPointExtensions
     [Pure]
     public static bool IsFinite(this float f)
 #if NETSTANDARD
-    => !float.IsNaN(f) && !float.IsInfinity(f);
+        => !float.IsNaN(f) && !float.IsInfinity(f);
 #else
         => float.IsFinite(f);
 #endif

--- a/src/Qowaiv.Validation.DataAnnotations/Qowaiv.Validation.DataAnnotations.csproj
+++ b/src/Qowaiv.Validation.DataAnnotations/Qowaiv.Validation.DataAnnotations.csproj
@@ -6,6 +6,8 @@
     <TargetFrameworks>netstandard2.0;net5.0;net6.0;net7.0</TargetFrameworks>
     <Version>1.4.0</Version>
     <PackageReleaseNotes>
+ToBeReleased
+- Introduction of [IsFinite] validation attribute.
 v1.4.0
 - Introduced [MultipleOf] validation attribute. #69
 - Marked [NestedModel] attribute as obsolete. #70

--- a/src/Qowaiv.Validation.DataAnnotations/QowaivValidationMessages.Designer.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/QowaivValidationMessages.Designer.cs
@@ -88,7 +88,7 @@ namespace Qowaiv.Validation.DataAnnotations {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The value of the {0} field is not a finate number..
+        ///   Looks up a localized string similar to The value of the {0} field is not a finite number..
         /// </summary>
         internal static string IsFiniteAttribute_ValidationError {
             get {

--- a/src/Qowaiv.Validation.DataAnnotations/QowaivValidationMessages.Designer.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/QowaivValidationMessages.Designer.cs
@@ -88,6 +88,15 @@ namespace Qowaiv.Validation.DataAnnotations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The value of the {0} field is not a finate number..
+        /// </summary>
+        internal static string IsFiniteAttribute_ValidationError {
+            get {
+                return ResourceManager.GetString("IsFiniteAttribute_ValidationError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The {0} field is required..
         /// </summary>
         internal static string MandatoryAttribute_ValidationError {

--- a/src/Qowaiv.Validation.DataAnnotations/QowaivValidationMessages.nl.resx
+++ b/src/Qowaiv.Validation.DataAnnotations/QowaivValidationMessages.nl.resx
@@ -15,6 +15,9 @@
   <data name="DistinctValuesAttribute_ValidationError" xml:space="preserve">
     <value>Alle waarden van het veld {0} zouden verschillend moeten zijn.</value>
   </data>
+  <data name="IsFiniteAttribute_ValidationError" xml:space="preserve">
+    <value>De waarde van het {0} veld is geen eindig getal.</value>
+  </data>
   <data name="MandatoryAttribute_ValidationError" xml:space="preserve">
     <value>Het veld {0} is verplicht.</value>
   </data>

--- a/src/Qowaiv.Validation.DataAnnotations/QowaivValidationMessages.resx
+++ b/src/Qowaiv.Validation.DataAnnotations/QowaivValidationMessages.resx
@@ -19,7 +19,7 @@
     <value>All values of the {0} field should be distinct.</value>
   </data>
   <data name="IsFiniteAttribute_ValidationError" xml:space="preserve">
-    <value>The value of the {0} field is not a finate number.</value>
+    <value>The value of the {0} field is not a finite number.</value>
   </data>
   <data name="MandatoryAttribute_ValidationError" xml:space="preserve">
     <value>The {0} field is required.</value>

--- a/src/Qowaiv.Validation.DataAnnotations/QowaivValidationMessages.resx
+++ b/src/Qowaiv.Validation.DataAnnotations/QowaivValidationMessages.resx
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-   <resheader name="resmimetype">
+ <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
   </resheader>
   <resheader name="reader">
@@ -17,6 +17,9 @@
   </data>
   <data name="DistinctValuesAttribute_ValidationError" xml:space="preserve">
     <value>All values of the {0} field should be distinct.</value>
+  </data>
+  <data name="IsFiniteAttribute_ValidationError" xml:space="preserve">
+    <value>The value of the {0} field is not a finate number.</value>
   </data>
   <data name="MandatoryAttribute_ValidationError" xml:space="preserve">
     <value>The {0} field is required.</value>

--- a/src/Qowaiv.Validation.DataAnnotations/README.md
+++ b/src/Qowaiv.Validation.DataAnnotations/README.md
@@ -107,7 +107,7 @@ public class Model
 
 ### Is finite
 The `[IsFinite]` attribute validates that the floating point value of the field
-represents a finite (e.a. not NaN, of infinity).
+represents a finite (e.a. not NaN, or infinity).
 
 ``` C#
 public class Model

--- a/src/Qowaiv.Validation.DataAnnotations/README.md
+++ b/src/Qowaiv.Validation.DataAnnotations/README.md
@@ -105,9 +105,21 @@ public class Model
 }
 ```
 
+### Is finite
+The `[IsFinite]` attribute validates that the floating point value of the field
+represents a finite (e.a. not NaN, of infinity).
+
+``` C#
+public class Model
+{
+    [IsFinite]
+    public double Number { get; set; }
+}
+```
+
 ### Multiple of
 The `[MultipleOf]` attribute validates that the value of a field is a multiple
-of the specified factor..
+of the specified factor.
 
 ``` C#
 public class Model

--- a/src/Qowaiv.Validation.Fluent/Extensions/System.FloatingPoints.cs
+++ b/src/Qowaiv.Validation.Fluent/Extensions/System.FloatingPoints.cs
@@ -1,0 +1,20 @@
+﻿namespace System;
+
+internal static class FloatingPointExtensions
+{
+    [Pure]
+    public static bool IsFinite(this double d)
+#if NETSTANDARD
+        => !double.IsNaN(d) && !double.IsInfinity(d);
+#else
+        => double.IsFinite(d);
+#endif
+
+    [Pure]
+    public static bool IsFinite(this float f)
+#if NETSTANDARD
+    => !float.IsNaN(f) && !float.IsInfinity(f);
+#else
+        => float.IsFinite(f);
+#endif
+}

--- a/src/Qowaiv.Validation.Fluent/Extensions/System.FloatingPoints.cs
+++ b/src/Qowaiv.Validation.Fluent/Extensions/System.FloatingPoints.cs
@@ -13,7 +13,7 @@ internal static class FloatingPointExtensions
     [Pure]
     public static bool IsFinite(this float f)
 #if NETSTANDARD
-    => !float.IsNaN(f) && !float.IsInfinity(f);
+        => !float.IsNaN(f) && !float.IsInfinity(f);
 #else
         => float.IsFinite(f);
 #endif

--- a/src/Qowaiv.Validation.Fluent/FluentValidation/FloatingPointValidation.cs
+++ b/src/Qowaiv.Validation.Fluent/FluentValidation/FloatingPointValidation.cs
@@ -3,7 +3,7 @@
 /// <summary>FLuent validation for <see cref="double"/> and <see cref="float"/>.</summary>
 public static class FloatingPointValidation
 {
-    /// <summary>The floating point should be a finite number..</summary>
+    /// <summary>The floating point should be a finite number.</summary>
     /// <typeparam name="TModel">
     /// Type of the model being validated.
     /// </typeparam>
@@ -16,7 +16,7 @@ public static class FloatingPointValidation
         .Must(number => number.IsFinite())
         .WithMessage(m => QowaivValidationFluentMessages.IsFinite);
 
-    /// <summary>The floating point should be a finite number..</summary>
+    /// <summary>The floating point should be a finite number.</summary>
     /// <typeparam name="TModel">
     /// Type of the model being validated.
     /// </typeparam>
@@ -29,7 +29,7 @@ public static class FloatingPointValidation
         .Must(number => !number.HasValue || number.Value.IsFinite())
         .WithMessage(m => QowaivValidationFluentMessages.IsFinite);
 
-    /// <summary>The floating point should be a finite number..</summary>
+    /// <summary>The floating point should be a finite number.</summary>
     /// <typeparam name="TModel">
     /// Type of the model being validated.
     /// </typeparam>
@@ -42,7 +42,7 @@ public static class FloatingPointValidation
         .Must(number => number.IsFinite())
         .WithMessage(m => QowaivValidationFluentMessages.IsFinite);
 
-    /// <summary>The floating point should be a finite number..</summary>
+    /// <summary>The floating point should be a finite number.</summary>
     /// <typeparam name="TModel">
     /// Type of the model being validated.
     /// </typeparam>

--- a/src/Qowaiv.Validation.Fluent/FluentValidation/FloatingPointValidation.cs
+++ b/src/Qowaiv.Validation.Fluent/FluentValidation/FloatingPointValidation.cs
@@ -1,0 +1,73 @@
+﻿namespace FluentValidation;
+
+/// <summary>FLuent validation for <see cref="double"/> and <see cref="float"/>.</summary>
+public static class FloatingPointValidation
+{
+    /// <summary>The floating point should be a finite number..</summary>
+    /// <typeparam name="TModel">
+    /// Type of the model being validated.
+    /// </typeparam>
+    /// <param name="ruleBuilder">
+    /// The rule builder on which the validator should be defined.
+    /// </param>
+    [FluentSyntax]
+    public static IRuleBuilderOptions<TModel, double> IsFinite<TModel>(this IRuleBuilder<TModel, double> ruleBuilder)
+        => Guard.NotNull(ruleBuilder, nameof(ruleBuilder))
+        .Must(IsFinite)
+        .WithMessage(m => QowaivValidationFluentMessages.IsFinite);
+
+    /// <summary>The floating point should be a finite number..</summary>
+    /// <typeparam name="TModel">
+    /// Type of the model being validated.
+    /// </typeparam>
+    /// <param name="ruleBuilder">
+    /// The rule builder on which the validator should be defined.
+    /// </param>
+    [FluentSyntax]
+    public static IRuleBuilderOptions<TModel, double?> IsFinite<TModel>(this IRuleBuilder<TModel, double?> ruleBuilder)
+        => Guard.NotNull(ruleBuilder, nameof(ruleBuilder))
+        .Must(number => !number.HasValue || IsFinite(number.Value))
+        .WithMessage(m => QowaivValidationFluentMessages.IsFinite);
+
+    /// <summary>The floating point should be a finite number..</summary>
+    /// <typeparam name="TModel">
+    /// Type of the model being validated.
+    /// </typeparam>
+    /// <param name="ruleBuilder">
+    /// The rule builder on which the validator should be defined.
+    /// </param>
+    [FluentSyntax]
+    public static IRuleBuilderOptions<TModel, float> IsFinite<TModel>(this IRuleBuilder<TModel, float> ruleBuilder)
+        => Guard.NotNull(ruleBuilder, nameof(ruleBuilder))
+        .Must(IsFinite)
+        .WithMessage(m => QowaivValidationFluentMessages.IsFinite);
+
+    /// <summary>The floating point should be a finite number..</summary>
+    /// <typeparam name="TModel">
+    /// Type of the model being validated.
+    /// </typeparam>
+    /// <param name="ruleBuilder">
+    /// The rule builder on which the validator should be defined.
+    /// </param>
+    [FluentSyntax]
+    public static IRuleBuilderOptions<TModel, float?> IsFinite<TModel>(this IRuleBuilder<TModel, float?> ruleBuilder)
+        => Guard.NotNull(ruleBuilder, nameof(ruleBuilder))
+        .Must(number => !number.HasValue || IsFinite(number.Value))
+        .WithMessage(m => QowaivValidationFluentMessages.IsFinite);
+
+    [Pure]
+    private static bool IsFinite(double number)
+#if NETSTANDARD
+        => !double.IsNaN(number) && !double.IsInfinity(number);
+#else
+        => double.IsFinite(number);
+#endif
+
+    [Pure]
+    private static bool IsFinite(float number)
+#if NETSTANDARD
+        => !float.IsNaN(number) && !float.IsInfinity(number);
+#else
+        => float.IsFinite(number);
+#endif
+}

--- a/src/Qowaiv.Validation.Fluent/FluentValidation/FloatingPointValidation.cs
+++ b/src/Qowaiv.Validation.Fluent/FluentValidation/FloatingPointValidation.cs
@@ -13,7 +13,7 @@ public static class FloatingPointValidation
     [FluentSyntax]
     public static IRuleBuilderOptions<TModel, double> IsFinite<TModel>(this IRuleBuilder<TModel, double> ruleBuilder)
         => Guard.NotNull(ruleBuilder, nameof(ruleBuilder))
-        .Must(IsFinite)
+        .Must(number => number.IsFinite())
         .WithMessage(m => QowaivValidationFluentMessages.IsFinite);
 
     /// <summary>The floating point should be a finite number..</summary>
@@ -26,7 +26,7 @@ public static class FloatingPointValidation
     [FluentSyntax]
     public static IRuleBuilderOptions<TModel, double?> IsFinite<TModel>(this IRuleBuilder<TModel, double?> ruleBuilder)
         => Guard.NotNull(ruleBuilder, nameof(ruleBuilder))
-        .Must(number => !number.HasValue || IsFinite(number.Value))
+        .Must(number => !number.HasValue || number.Value.IsFinite())
         .WithMessage(m => QowaivValidationFluentMessages.IsFinite);
 
     /// <summary>The floating point should be a finite number..</summary>
@@ -39,7 +39,7 @@ public static class FloatingPointValidation
     [FluentSyntax]
     public static IRuleBuilderOptions<TModel, float> IsFinite<TModel>(this IRuleBuilder<TModel, float> ruleBuilder)
         => Guard.NotNull(ruleBuilder, nameof(ruleBuilder))
-        .Must(IsFinite)
+        .Must(number => number.IsFinite())
         .WithMessage(m => QowaivValidationFluentMessages.IsFinite);
 
     /// <summary>The floating point should be a finite number..</summary>
@@ -52,22 +52,6 @@ public static class FloatingPointValidation
     [FluentSyntax]
     public static IRuleBuilderOptions<TModel, float?> IsFinite<TModel>(this IRuleBuilder<TModel, float?> ruleBuilder)
         => Guard.NotNull(ruleBuilder, nameof(ruleBuilder))
-        .Must(number => !number.HasValue || IsFinite(number.Value))
+        .Must(number => !number.HasValue || number.Value.IsFinite())
         .WithMessage(m => QowaivValidationFluentMessages.IsFinite);
-
-    [Pure]
-    private static bool IsFinite(double number)
-#if NETSTANDARD
-        => !double.IsNaN(number) && !double.IsInfinity(number);
-#else
-        => double.IsFinite(number);
-#endif
-
-    [Pure]
-    private static bool IsFinite(float number)
-#if NETSTANDARD
-        => !float.IsNaN(number) && !float.IsInfinity(number);
-#else
-        => float.IsFinite(number);
-#endif
 }

--- a/src/Qowaiv.Validation.Fluent/Qowaiv.Validation.Fluent.csproj
+++ b/src/Qowaiv.Validation.Fluent/Qowaiv.Validation.Fluent.csproj
@@ -6,6 +6,8 @@
     <TargetFrameworks>netstandard2.0;net5.0;net6.0;net7.0</TargetFrameworks>
     <Version>0.3.0</Version>
     <PackageReleaseNotes>
+ToBeReleaased
+- `.IsFinite()` for doubles and floats.
 v0.3.0
 - Support .NET 7.0. #62
 v0.2.1

--- a/src/Qowaiv.Validation.Fluent/QowaivValidationFluentMessages.Designer.cs
+++ b/src/Qowaiv.Validation.Fluent/QowaivValidationFluentMessages.Designer.cs
@@ -19,7 +19,7 @@ namespace Qowaiv.Validation.Fluent {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class QowaivValidationFluentMessages {
@@ -75,6 +75,15 @@ namespace Qowaiv.Validation.Fluent {
         internal static string InPast {
             get {
                 return ResourceManager.GetString("InPast", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;{PropertyName}&apos; must be a finite number..
+        /// </summary>
+        internal static string IsFinite {
+            get {
+                return ResourceManager.GetString("IsFinite", resourceCulture);
             }
         }
         

--- a/src/Qowaiv.Validation.Fluent/QowaivValidationFluentMessages.nl.resx
+++ b/src/Qowaiv.Validation.Fluent/QowaivValidationFluentMessages.nl.resx
@@ -3,20 +3,20 @@
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
   </resheader>
-  <resheader name="version">
-    <value>2.0</value>
-  </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter</value>
   </resheader>
   <data name="InFuture" xml:space="preserve">
     <value>'{PropertyName}' moet in de toekomst liggen.</value>
   </data>
   <data name="InPast" xml:space="preserve">
     <value>'{PropertyName}' moet in het verleden liggen.</value>
+  </data>
+  <data name="IsFinite" xml:space="preserve">
+    <value>'{PropertyName}' moet een eindig getal zijn.</value>
   </data>
   <data name="NoIPBasedEmailAddress" xml:space="preserve">
     <value>'{PropertyName}' heeft een IP-adres als domein.</value>

--- a/src/Qowaiv.Validation.Fluent/QowaivValidationFluentMessages.resx
+++ b/src/Qowaiv.Validation.Fluent/QowaivValidationFluentMessages.resx
@@ -3,20 +3,20 @@
   <resheader name="resmimetype">
     <value>text/microsoft-resx</value>
   </resheader>
-  <resheader name="version">
-    <value>2.0</value>
-  </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter</value>
   </resheader>
   <data name="InFuture" xml:space="preserve">
     <value>'{PropertyName}' should be in the future.</value>
   </data>
   <data name="InPast" xml:space="preserve">
     <value>'{PropertyName}' should be in the past.</value>
+  </data>
+  <data name="IsFinite" xml:space="preserve">
+    <value>'{PropertyName}' must be a finite number.</value>
   </data>
   <data name="NoIPBasedEmailAddress" xml:space="preserve">
     <value>'{PropertyName}' has a IP address based domain.</value>

--- a/src/Qowaiv.Validation.Fluent/README.md
+++ b/src/Qowaiv.Validation.Fluent/README.md
@@ -79,7 +79,7 @@ public class CustomValidator : AbstractValidator<Model>
     }
 }
 ```
-### Email address should no be IP-based
+### Email address should not be IP-based
 The `EmailAddressValidation` validates that an `EmailAddress`
 does not have an IP-based domain.
 

--- a/src/Qowaiv.Validation.Fluent/README.md
+++ b/src/Qowaiv.Validation.Fluent/README.md
@@ -1,1 +1,94 @@
-﻿# Qowaiv Validation
+﻿# Qowaiv exensions on [*Fluent Validation](https://fluentvalidation.net/)
+
+## Validators
+
+### Required
+The `RequiredValidation` validates that a required property has a set value. If
+specified, an unknown value can be seen as a set value, by default it is not.
+
+``` C#
+public class CustomValidator : AbstractValidator<Model>
+{
+    public CustomValidator()
+    {
+        RuleFor(m => m.Email).Required();
+        RuleFor(m => m.Iban).Required(allowUnknown: true);
+    }
+}
+```
+
+### Not unknown
+The `UnknownValidation` validates that a value does not equal the Unknown
+value (if existing of course). Accessible via the fluent syntax.
+
+``` C#
+public class CustomValidator : AbstractValidator<Model>
+{
+    public CustomValidator()
+    {
+        RuleFor(m => m.Email).NotEmptyOrUnknown();
+        RuleFor(m => m.Iban).NotUnknown();
+    }
+}
+```
+
+### Relative to the clock
+
+The `ClockValidation` validates if a date (time) is in the past, or future.
+It supports `Date`, `DateTime`, `Date?`, and `DateTime?`, and the provision
+of custom date (time) provider. By Default, `Clock.Now()` and `Clock.Today()`
+are used.
+
+``` C#
+public class CustomValidator : AbstractValidator<Model>
+{
+    public CustomValidator()
+    {
+        RuleFor(m => m.Date1).InFuture();
+        RuleFor(m => m.Date2).InPast();
+        RuleFor(m => m.Date3).NotInFuture();
+        RuleFor(m => m.Date4).NotInPast(() => CustomeDateProvider());
+    }
+}
+```
+
+### Postal code valid for specific country
+The `PostalCodeValidation` validates that a `PostalCode` value is valid for
+a specific `Country`, both static and via another property.
+
+``` C#
+public class CustomValidator : AbstractValidator<Model>
+{
+    public CustomValidator()
+    {
+        RuleFor(m => m.PostalCode).ValidFor(m => m.Country);
+    }
+}
+```
+
+### Finite floating points
+The `FloatingPointValidation` validates that `double` and `float` values
+are finite numbers.
+
+``` C#
+public class CustomValidator : AbstractValidator<Model>
+{
+    public CustomValidator()
+    {
+        RuleFor(m => m.Number).IsFinite();
+    }
+}
+```
+### Email address should be IP-based
+The `EmailAddressValidation` validates that an `EmailAddress`
+does not have an IP-based domain.
+
+``` C#
+public class CustomValidator : AbstractValidator<Model>
+{
+    public CustomValidator()
+    {
+        RuleFor(m => m.Email).NotIPBased();
+    }
+}
+```

--- a/src/Qowaiv.Validation.Fluent/README.md
+++ b/src/Qowaiv.Validation.Fluent/README.md
@@ -79,7 +79,7 @@ public class CustomValidator : AbstractValidator<Model>
     }
 }
 ```
-### Email address should be IP-based
+### Email address should no be IP-based
 The `EmailAddressValidation` validates that an `EmailAddress`
 does not have an IP-based domain.
 


### PR DESCRIPTION
As `double`'s (and `float`'s) can be assigned as `NaN`, `PositiveInfinity`, and `NegativeInfinity`, it useful to add validation that disallows these values if desired.

- [x] FluentValidation
- [x] DataAnnotations 
- [x] documentation