### PR TITLE
extend midair collision factory method

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-![Qowaiv](https://github.com/Qowaiv/Qowaiv/blob/master/design/qowaiv-logo_linkedin_100x060.jpg)
+﻿![Qowaiv](https://github.com/Qowaiv/Qowaiv/blob/master/design/qowaiv-logo_linkedin_100x060.jpg)
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 [![Code of Conduct](https://img.shields.io/badge/%E2%9D%A4-code%20of%20conduct-blue.svg?style=flat)](https://github.com/Qowaiv/qowaiv-validation/blob/master/CODE_OF_CONDUCT.md)
 
-| version                                                                       | package                                                                                             |
-|-------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------|
-|![v](https://img.shields.io/badge/version-0.3.0-darkblue.svg?cacheSeconds=3600)|[Qowaiv.Validation.Abstractions](https://www.nuget.org/packages/Qowaiv.Validation.Abstractions)      |
-|![v](https://img.shields.io/badge/version-1.4.0-blue.svg?cacheSeconds=3600)    |[Qowaiv.Validation.DataAnnotations](https://www.nuget.org/packages/Qowaiv.Validation.DataAnnotations)|
-|![v](https://img.shields.io/badge/version-0.3.0-blue.svg?cacheSeconds=3600)    |[Qowaiv.Validation.Fluent](https://www.nuget.org/packages/Qowaiv.Validation.Fluent)                  |
-|![v](https://img.shields.io/badge/version-0.3.0-blue.svg?cacheSeconds=3600)    |[Qowaiv.Validation.Guarding](https://www.nuget.org/packages/Qowaiv.Validation.Guarding)              |
-|![v](https://img.shields.io/badge/version-0.3.0-blue.svg?cacheSeconds=3600)    |[Qowaiv.Validation.Messages](https://www.nuget.org/packages/Qowaiv.Validation.Messages)              |
-|![v](https://img.shields.io/badge/version-0.3.0-blue.svg?cacheSeconds=3600)    |[Qowaiv.Validation.Xml](https://www.nuget.org/packages/Qowaiv.Validation.Xml)                        |
-|![v](https://img.shields.io/badge/version-0.3.0-darkred.svg?cacheSeconds=3600) |[Qowaiv.Validation.TestTools](https://www.nuget.org/packages/Qowaiv.TestTools)                       |
+| version                                                                        | downloads                                                             | package                                                                                              |
+|--------------------------------------------------------------------------------|-----------------------------------------------------------------------|------------------------------------------------------------------------------------------------------|
+|![v](https://img.shields.io/nuget/v/Qowaiv.Validation.Abstractions?color=18C)   |![v](https://img.shields.io/nuget/dt/Qowaiv.Validation.Abstractions)   |[Qowaiv.Validation.Abstractions](https://www.nuget.org/packages/Qowaiv.Validation.Abstractions/)      |
+|![v](https://img.shields.io/nuget/v/Qowaiv.Validation.DataAnnotations?color=18C)|![v](https://img.shields.io/nuget/dt/Qowaiv.Validation.DataAnnotations)|[Qowaiv.Validation.DataAnnotations](https://www.nuget.org/packages/Qowaiv.Validation.DataAnnotations/)|
+|![v](https://img.shields.io/nuget/v/Qowaiv.Validation.Fluent?color=18C)         |![v](https://img.shields.io/nuget/dt/Qowaiv.Validation.Fluent)         |[Qowaiv.Validation.Fluent](https://www.nuget.org/packages/Qowaiv.Validation.Fluent/)                  |
+|![v](https://img.shields.io/nuget/v/Qowaiv.Validation.Guarding?color=18C)       |![v](https://img.shields.io/nuget/dt/Qowaiv.Validation.Guarding)       |[Qowaiv.Validation.Guarding](https://www.nuget.org/packages/Qowaiv.Validation.Guarding/)              |
+|![v](https://img.shields.io/nuget/v/Qowaiv.Validation.Messages?color=18C)       |![v](https://img.shields.io/nuget/dt/Qowaiv.Validation.Messages)       |[Qowaiv.Validation.Messages](https://www.nuget.org/packages/Qowaiv.Validation.Messages/)              |
+|![v](https://img.shields.io/nuget/v/Qowaiv.Validation.Xml?color=18C)            |![v](https://img.shields.io/nuget/dt/Qowaiv.Validation.Xml)            |[Qowaiv.Validation.Xml](https://www.nuget.org/packages/Qowaiv.Validation.Xml/)                        |
+|![v](https://img.shields.io/nuget/v/Qowaiv.Validation.TestTools?color=118)      |![v](https://img.shields.io/nuget/dt/Qowaiv.Validation.TestTools)      |[Qowaiv.Validation.TestTools](https://www.nuget.org/packages/Qowaiv.Validation.TestTools/)            |
 
 # Qowaiv Validation
 There are multiple ways to support validation within .NET. Most notable are

--- a/src/Qowaiv.Validation.Messages/ConcurrencyIssue.cs
+++ b/src/Qowaiv.Validation.Messages/ConcurrencyIssue.cs
@@ -36,4 +36,10 @@ public class ConcurrencyIssue : InvalidOperationException, IValidationMessage
     [Pure]
     public static ConcurrencyIssue MidAirCollision()
         => new(ValidationMessages.MidAirCollision);
+
+    /// <summary>Creates an <see cref="ConcurrencyIssue"/> for mid-air collision.</summary>
+    [Pure]
+    public static ConcurrencyIssue MidAirCollision(Exception innerException)
+        => new(ValidationMessages.MidAirCollision, innerException);
+
 }

--- a/src/Qowaiv.Validation.Messages/Qowaiv.Validation.Messages.csproj
+++ b/src/Qowaiv.Validation.Messages/Qowaiv.Validation.Messages.csproj
@@ -4,8 +4,10 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net5.0;net6.0;net7.0</TargetFrameworks>
-    <Version>0.3.0</Version>
+    <Version>0.3.1</Version>
     <PackageReleaseNotes>
+v0.3.1
+- Extend ConcurrencyIssue factory method with innerException overload.
 v0.3.0
 - Support .NET 7.0. #62
 v0.2.1


### PR DESCRIPTION
In cases that a midair collision is communicated, it is common that a exception is caught. It is preferable, that this exception can be added.