### PR TITLE
Messages should be culture dependent

### DIFF
--- a/src/Qowaiv.Validation.Fluent/FluentValidation/ClockValidation.cs
+++ b/src/Qowaiv.Validation.Fluent/FluentValidation/ClockValidation.cs
@@ -22,7 +22,7 @@ public static partial class ClockValidation
 
         return ruleBuilder
             .Must(date => date > now())
-            .WithMessage(m => QowaivValidationFluentMessages.InFuture);
+            .WithMessage(_ => QowaivValidationFluentMessages.InFuture);
     }
 
     /// <summary>Requires a date time to be in the future (if set).</summary>
@@ -44,7 +44,7 @@ public static partial class ClockValidation
 
         return ruleBuilder
             .Must(date => !date.HasValue || date.Value > now())
-            .WithMessage(m => QowaivValidationFluentMessages.InFuture);
+            .WithMessage(_ => QowaivValidationFluentMessages.InFuture);
     }
 
     /// <summary>Requires a date to be in the future.</summary>
@@ -66,7 +66,7 @@ public static partial class ClockValidation
 
         return ruleBuilder
             .Must(date => date > today())
-            .WithMessage(m => QowaivValidationFluentMessages.InFuture);
+            .WithMessage(_ => QowaivValidationFluentMessages.InFuture);
     }
 
     /// <summary>Requires a date to be in the future (if set).</summary>
@@ -88,7 +88,7 @@ public static partial class ClockValidation
 
         return ruleBuilder
             .Must(date => !date.HasValue || date.Value > today())
-            .WithMessage(m => QowaivValidationFluentMessages.InFuture);
+            .WithMessage(_ => QowaivValidationFluentMessages.InFuture);
     }
 
     /// <summary>Requires a date time not to be in the future.</summary>
@@ -110,7 +110,7 @@ public static partial class ClockValidation
 
         return ruleBuilder
             .Must(date => date <= now())
-            .WithMessage(m => QowaivValidationFluentMessages.NotInFuture);
+            .WithMessage(_ => QowaivValidationFluentMessages.NotInFuture);
     }
 
     /// <summary>Requires a date time not to be in the future (if set).</summary>
@@ -132,7 +132,7 @@ public static partial class ClockValidation
 
         return ruleBuilder
             .Must(date => !date.HasValue || date.Value <= now())
-            .WithMessage(m => QowaivValidationFluentMessages.NotInFuture);
+            .WithMessage(_ => QowaivValidationFluentMessages.NotInFuture);
     }
 
     /// <summary>Requires a date not to be in the future.</summary>
@@ -154,7 +154,7 @@ public static partial class ClockValidation
 
         return ruleBuilder
             .Must(date => date <= today())
-            .WithMessage(m => QowaivValidationFluentMessages.NotInFuture);
+            .WithMessage(_ => QowaivValidationFluentMessages.NotInFuture);
     }
 
     /// <summary>Requires a date not to be in the future (if set).</summary>
@@ -176,7 +176,7 @@ public static partial class ClockValidation
 
         return ruleBuilder
             .Must(date => !date.HasValue || date.Value <= today())
-            .WithMessage(m => QowaivValidationFluentMessages.NotInFuture);
+            .WithMessage(_ => QowaivValidationFluentMessages.NotInFuture);
     }
 
     /// <summary>Requires a date time to be in the past.</summary>
@@ -198,7 +198,7 @@ public static partial class ClockValidation
 
         return ruleBuilder
             .Must(date => date < now())
-            .WithMessage(m => QowaivValidationFluentMessages.InPast);
+            .WithMessage(_ => QowaivValidationFluentMessages.InPast);
     }
 
     /// <summary>Requires a date time to be in the past (if set).</summary>
@@ -220,7 +220,7 @@ public static partial class ClockValidation
 
         return ruleBuilder
             .Must(date => !date.HasValue || date.Value < now())
-            .WithMessage(m => QowaivValidationFluentMessages.InPast);
+            .WithMessage(_ => QowaivValidationFluentMessages.InPast);
     }
 
     /// <summary>Requires a date to be in the past.</summary>
@@ -242,7 +242,7 @@ public static partial class ClockValidation
 
         return ruleBuilder
             .Must(date => date < today())
-            .WithMessage(m => QowaivValidationFluentMessages.InPast);
+            .WithMessage(_ => QowaivValidationFluentMessages.InPast);
     }
 
     /// <summary>Requires a date to be in the past (if set).</summary>
@@ -264,7 +264,7 @@ public static partial class ClockValidation
 
         return ruleBuilder
             .Must(date => !date.HasValue || date.Value < today())
-            .WithMessage(m => QowaivValidationFluentMessages.InPast);
+            .WithMessage(_ => QowaivValidationFluentMessages.InPast);
     }
 
     /// <summary>Requires a date time not to be in the past.</summary>
@@ -286,7 +286,7 @@ public static partial class ClockValidation
 
         return ruleBuilder
             .Must(date => date >= now())
-            .WithMessage(m => QowaivValidationFluentMessages.NotInPast);
+            .WithMessage(_ => QowaivValidationFluentMessages.NotInPast);
     }
 
     /// <summary>Requires a date time not to be in the past (if set).</summary>
@@ -308,7 +308,7 @@ public static partial class ClockValidation
 
         return ruleBuilder
             .Must(date => !date.HasValue || date.Value >= now())
-            .WithMessage(m => QowaivValidationFluentMessages.NotInPast);
+            .WithMessage(_ => QowaivValidationFluentMessages.NotInPast);
     }
 
     /// <summary>Requires a date not to be in the past.</summary>
@@ -330,7 +330,7 @@ public static partial class ClockValidation
 
         return ruleBuilder
             .Must(date => date >= today())
-            .WithMessage(m => QowaivValidationFluentMessages.NotInPast);
+            .WithMessage(_ => QowaivValidationFluentMessages.NotInPast);
     }
 
     /// <summary>Requires a date not to be in the past (if set).</summary>
@@ -352,6 +352,6 @@ public static partial class ClockValidation
 
         return ruleBuilder
             .Must(date => !date.HasValue || date.Value >= today())
-            .WithMessage(m => QowaivValidationFluentMessages.NotInPast);
+            .WithMessage(_ => QowaivValidationFluentMessages.NotInPast);
     }
 }

--- a/src/Qowaiv.Validation.Fluent/FluentValidation/ClockValidation.net6.0.cs
+++ b/src/Qowaiv.Validation.Fluent/FluentValidation/ClockValidation.net6.0.cs
@@ -24,7 +24,7 @@ public static partial class ClockValidation
 
         return ruleBuilder
             .Must(date => date > today())
-            .WithMessage(m => QowaivValidationFluentMessages.InFuture);
+            .WithMessage(_ => QowaivValidationFluentMessages.InFuture);
     }
 
     /// <summary>Requires a date to be in the future (if set).</summary>
@@ -46,7 +46,7 @@ public static partial class ClockValidation
 
         return ruleBuilder
             .Must(date => !date.HasValue || date.Value > today())
-            .WithMessage(m => QowaivValidationFluentMessages.InFuture);
+            .WithMessage(_ => QowaivValidationFluentMessages.InFuture);
     }
 
     /// <summary>Requires a date not to be in the future.</summary>
@@ -68,7 +68,7 @@ public static partial class ClockValidation
 
         return ruleBuilder
             .Must(date => date <= today())
-            .WithMessage(m => QowaivValidationFluentMessages.NotInFuture);
+            .WithMessage(_ => QowaivValidationFluentMessages.NotInFuture);
     }
 
     /// <summary>Requires a date not to be in the future (if set).</summary>
@@ -90,7 +90,7 @@ public static partial class ClockValidation
 
         return ruleBuilder
             .Must(date => !date.HasValue || date.Value <= today())
-            .WithMessage(m => QowaivValidationFluentMessages.NotInFuture);
+            .WithMessage(_ => QowaivValidationFluentMessages.NotInFuture);
     }
 
     /// <summary>Requires a date to be in the past.</summary>
@@ -112,7 +112,7 @@ public static partial class ClockValidation
 
         return ruleBuilder
             .Must(date => date < today())
-            .WithMessage(m => QowaivValidationFluentMessages.InPast);
+            .WithMessage(_ => QowaivValidationFluentMessages.InPast);
     }
 
     /// <summary>Requires a date to be in the past (if set).</summary>
@@ -134,7 +134,7 @@ public static partial class ClockValidation
 
         return ruleBuilder
             .Must(date => !date.HasValue || date.Value < today())
-            .WithMessage(m => QowaivValidationFluentMessages.InPast);
+            .WithMessage(_ => QowaivValidationFluentMessages.InPast);
     }
 
     /// <summary>Requires a date not to be in the past.</summary>
@@ -156,7 +156,7 @@ public static partial class ClockValidation
 
         return ruleBuilder
             .Must(date => date >= today())
-            .WithMessage(m => QowaivValidationFluentMessages.NotInPast);
+            .WithMessage(_ => QowaivValidationFluentMessages.NotInPast);
     }
 
     /// <summary>Requires a date not to be in the past (if set).</summary>
@@ -178,7 +178,7 @@ public static partial class ClockValidation
 
         return ruleBuilder
             .Must(date => !date.HasValue || date.Value >= today())
-            .WithMessage(m => QowaivValidationFluentMessages.NotInPast);
+            .WithMessage(_ => QowaivValidationFluentMessages.NotInPast);
     }
 
     [Pure]

--- a/src/Qowaiv.Validation.Fluent/FluentValidation/EmailAddressValidation.cs
+++ b/src/Qowaiv.Validation.Fluent/FluentValidation/EmailAddressValidation.cs
@@ -14,5 +14,5 @@ public static class EmailAddressValidation
     public static IRuleBuilderOptions<TModel, EmailAddress> NotIPBased<TModel>(this IRuleBuilder<TModel, EmailAddress> ruleBuilder)
         => Guard.NotNull(ruleBuilder, nameof(ruleBuilder))
         .Must(emailAddress => !emailAddress.IsIPBased)
-        .WithMessage(m => QowaivValidationFluentMessages.NoIPBasedEmailAddress);
+        .WithMessage(_ => QowaivValidationFluentMessages.NoIPBasedEmailAddress);
 }

--- a/src/Qowaiv.Validation.Fluent/FluentValidation/FloatingPointValidation.cs
+++ b/src/Qowaiv.Validation.Fluent/FluentValidation/FloatingPointValidation.cs
@@ -14,7 +14,7 @@ public static class FloatingPointValidation
     public static IRuleBuilderOptions<TModel, double> IsFinite<TModel>(this IRuleBuilder<TModel, double> ruleBuilder)
         => Guard.NotNull(ruleBuilder, nameof(ruleBuilder))
         .Must(number => number.IsFinite())
-        .WithMessage(m => QowaivValidationFluentMessages.IsFinite);
+        .WithMessage(_ => QowaivValidationFluentMessages.IsFinite);
 
     /// <summary>The floating point should be a finite number.</summary>
     /// <typeparam name="TModel">
@@ -27,7 +27,7 @@ public static class FloatingPointValidation
     public static IRuleBuilderOptions<TModel, double?> IsFinite<TModel>(this IRuleBuilder<TModel, double?> ruleBuilder)
         => Guard.NotNull(ruleBuilder, nameof(ruleBuilder))
         .Must(number => !number.HasValue || number.Value.IsFinite())
-        .WithMessage(m => QowaivValidationFluentMessages.IsFinite);
+        .WithMessage(_ => QowaivValidationFluentMessages.IsFinite);
 
     /// <summary>The floating point should be a finite number.</summary>
     /// <typeparam name="TModel">
@@ -40,7 +40,7 @@ public static class FloatingPointValidation
     public static IRuleBuilderOptions<TModel, float> IsFinite<TModel>(this IRuleBuilder<TModel, float> ruleBuilder)
         => Guard.NotNull(ruleBuilder, nameof(ruleBuilder))
         .Must(number => number.IsFinite())
-        .WithMessage(m => QowaivValidationFluentMessages.IsFinite);
+        .WithMessage(_ => QowaivValidationFluentMessages.IsFinite);
 
     /// <summary>The floating point should be a finite number.</summary>
     /// <typeparam name="TModel">
@@ -53,5 +53,5 @@ public static class FloatingPointValidation
     public static IRuleBuilderOptions<TModel, float?> IsFinite<TModel>(this IRuleBuilder<TModel, float?> ruleBuilder)
         => Guard.NotNull(ruleBuilder, nameof(ruleBuilder))
         .Must(number => !number.HasValue || number.Value.IsFinite())
-        .WithMessage(m => QowaivValidationFluentMessages.IsFinite);
+        .WithMessage(_ => QowaivValidationFluentMessages.IsFinite);
 }

--- a/src/Qowaiv.Validation.Fluent/FluentValidation/PostalCodeValidation.cs
+++ b/src/Qowaiv.Validation.Fluent/FluentValidation/PostalCodeValidation.cs
@@ -32,7 +32,7 @@ public static class PostalCodeValidation
     public static IRuleBuilderOptions<TModel, PostalCode> ValidFor<TModel>(this IRuleBuilder<TModel, PostalCode> ruleBuilder, Func<TModel, Country> country)
         => Guard.NotNull(ruleBuilder, nameof(ruleBuilder))
             .Must((model, postalCode, context) => IsValidFor(postalCode, country(model), context))
-            .WithMessage(m => QowaivValidationFluentMessages.PostalCodeValidForCountry);
+            .WithMessage(_ => QowaivValidationFluentMessages.PostalCodeValidForCountry);
 
     [Impure]
     private static bool IsValidFor<TModel>(PostalCode postalCode, Country country, ValidationContext<TModel> context)

--- a/src/Qowaiv.Validation.Fluent/FluentValidation/RequiredValidation.cs
+++ b/src/Qowaiv.Validation.Fluent/FluentValidation/RequiredValidation.cs
@@ -37,8 +37,8 @@ public static class RequiredValidation
 
         return allowUnknown
             ? ruleBuilder
-                .NotEmpty().WithMessage(QowaivValidationFluentMessages.Required)
+                .NotEmpty().WithMessage(_ => QowaivValidationFluentMessages.Required)
             : ruleBuilder
-                .NotEmptyOrUnknown().WithMessage(QowaivValidationFluentMessages.Required);
+                .NotEmptyOrUnknown().WithMessage(_ => QowaivValidationFluentMessages.Required);
     }
 }

--- a/src/Qowaiv.Validation.Fluent/FluentValidation/UnknownValidation.cs
+++ b/src/Qowaiv.Validation.Fluent/FluentValidation/UnknownValidation.cs
@@ -19,7 +19,7 @@ public static class UnknownValidation
     public static IRuleBuilderOptions<TModel, TProperty> NotUnknown<TModel, TProperty>(this IRuleBuilder<TModel, TProperty> ruleBuilder)
         => Guard.NotNull(ruleBuilder, nameof(ruleBuilder))
         .Must(prop => prop is null || !Equals(Unknown.Value(typeof(TProperty)), prop))
-        .WithMessage(m => QowaivValidationFluentMessages.NotUnknown);
+        .WithMessage(_ => QowaivValidationFluentMessages.NotUnknown);
 
     /// <summary>Defines a 'not empty' and a 'not unkmown' validator on the current rule builder.</summary>
     /// <typeparam name="TModel">Type of object being validated.</typeparam>
@@ -29,5 +29,5 @@ public static class UnknownValidation
     public static IRuleBuilderOptions<TModel, TProperty> NotEmptyOrUnknown<TModel, TProperty>(this IRuleBuilder<TModel, TProperty> ruleBuilder)
         => Guard.NotNull(ruleBuilder, nameof(ruleBuilder))
         .SetValidator(new NotEmptyOrUnknownValidator<TModel, TProperty>())
-        .WithMessage(m => QowaivValidationFluentMessages.NotEmptyOrUnknown);
+        .WithMessage(_ => QowaivValidationFluentMessages.NotEmptyOrUnknown);
 }

--- a/src/Qowaiv.Validation.Fluent/Qowaiv.Validation.Fluent.csproj
+++ b/src/Qowaiv.Validation.Fluent/Qowaiv.Validation.Fluent.csproj
@@ -4,10 +4,11 @@
   
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
-    <Version>0.3.0</Version>
+    <Version>0.3.1</Version>
     <PackageId>Qowaiv.Validation.Fluent</PackageId>
     <PackageReleaseNotes>
-ToBeReleaased
+v0.3.1
+- FIx so that Required to be current culture dependent. #74
 - `.IsFinite()` for doubles and floats.
 v0.3.0
 - Support .NET 7.0. #62


### PR DESCRIPTION
Closes #74 : For required, the messages where only initiated for the then active culture, instead of being decided once called. This PR fixes that. 