### PR TITLE
Add Length and Count related attributes

### DIFF
--- a/specs/Qowaiv.Validation.Specs/DataAnnotations/Attributes/Collection_specs.cs
+++ b/specs/Qowaiv.Validation.Specs/DataAnnotations/Attributes/Collection_specs.cs
@@ -35,11 +35,11 @@ public class At_least
     public void validates([Range(4, 10)] int value) => new Collection.AtLeastAttribute(4).IsValid(new byte[value]).Should().BeTrue();
 
     [Test]
-    public void Invalidates([Range(1, 10)] int value) => new Collection.AtLeastAttribute(11).IsValid(new byte[value]).Should().BeFalse();
+    public void invalidates([Range(1, 10)] int value) => new Collection.AtLeastAttribute(11).IsValid(new byte[value]).Should().BeFalse();
 
     [TestCase("nl", "Veld AtLeastProp moet tenminste 4 items bevatten.")]
     [TestCase("en", "The AtLeastProp field should have at least 4 items.")]
-    public void With_message(CultureInfo culture, string message)
+    public void with_message(CultureInfo culture, string message)
     {
         using var _ = culture.Scoped();
         new Model() {AtLeastProp = "a" }.Should().BeInvalidFor(new AnnotatedModelValidator<Model>())
@@ -76,11 +76,11 @@ public class At_most
     public void validates([Range(1, 4)] int value) => new Collection.AtMostAttribute(4).IsValid(new byte[value]).Should().BeTrue();
 
     [Test]
-    public void Invalidates([Range(12, 20)] int value) => new Collection.AtMostAttribute(11).IsValid(new byte[value]).Should().BeFalse();
+    public void invalidates([Range(12, 20)] int value) => new Collection.AtMostAttribute(11).IsValid(new byte[value]).Should().BeFalse();
 
     [TestCase("nl", "Veld AtMostProp mag niet meer dan 4 items bevatten.")]
     [TestCase("en", "The AtMostProp field should have at most 4 items.")]
-    public void With_message(CultureInfo culture, string message)
+    public void with_message(CultureInfo culture, string message)
     {
         using var _ = culture.Scoped();
         new Model() { AtMostProp = "abcde" }.Should().BeInvalidFor(new AnnotatedModelValidator<Model>())
@@ -126,11 +126,11 @@ public class In_range
     [TestCase(5)]
     [TestCase(6)]
     [TestCase(7)]
-    public void Invalidates(int value) => new Collection.InRangeAttribute(3, 4).IsValid(new byte[value]).Should().BeFalse();
+    public void invalidates(int value) => new Collection.InRangeAttribute(3, 4).IsValid(new byte[value]).Should().BeFalse();
 
     [TestCase("nl", "Het aantal items van veld InRangeProp moet tussen 3 en 4 zitten.")]
     [TestCase("en", "The number of items of the InRangeProp field should be between 3 and 4.")]
-    public void With_message(CultureInfo culture, string message)
+    public void with_message(CultureInfo culture, string message)
     {
         using var _ = culture.Scoped();
         new Model() { InRangeProp = "a" }.Should().BeInvalidFor(new AnnotatedModelValidator<Model>())

--- a/specs/Qowaiv.Validation.Specs/DataAnnotations/Attributes/Collection_specs.cs
+++ b/specs/Qowaiv.Validation.Specs/DataAnnotations/Attributes/Collection_specs.cs
@@ -22,7 +22,7 @@ public class At_least
             .Should().Throw<UnsupportedType>().WithMessage("Collection.AtLeastAttribute does not support properties of the type object.");
     }
 
-    public class Ingores
+    public class Ignores
     {
         [Test]
         public void @null() => new Collection.AtLeastAttribute(0).IsValid(null).Should().BeTrue();
@@ -66,7 +66,7 @@ public class At_most
             .Should().Throw<UnsupportedType>().WithMessage("Collection.AtMostAttribute does not support properties of the type object.");
     }
 
-    public class Ingores
+    public class Ignores
     {
         [Test]
         public void @null() => new Collection.AtMostAttribute(0).IsValid(null).Should().BeTrue();
@@ -108,7 +108,7 @@ public class In_range
     }
 
 
-    public class Ingores
+    public class Ignores
     {
         [Test]
         public void @null() => new Collection.InRangeAttribute(2, 4).IsValid(null).Should().BeTrue();

--- a/specs/Qowaiv.Validation.Specs/DataAnnotations/Attributes/Collection_specs.cs
+++ b/specs/Qowaiv.Validation.Specs/DataAnnotations/Attributes/Collection_specs.cs
@@ -1,0 +1,153 @@
+﻿using Qowaiv.Validation.DataAnnotations;
+using RangeAttribute = NUnit.Framework.RangeAttribute;
+
+namespace Data_annotations.Attributes.Collection_specs;
+
+public class At_least
+{
+    public class Supports
+    {
+        [Test]
+        public void ICollection() => new Collection.AtLeastAttribute(2).IsValid(new[] { 1, 2 }).Should().BeTrue();
+
+        [Test]
+        public void type_with_count_property() => new Collection.AtLeastAttribute(4).IsValid(new MyCollection(17)).Should().BeTrue();
+    }
+
+    public class Does_not_support
+    {
+        [Test]
+        public void type_without_count_property()
+            => new Collection.AtLeastAttribute(4).Invoking(a => a.IsValid(new object()))
+            .Should().Throw<UnsupportedType>().WithMessage("Collection.AtLeastAttribute does not support properties of the type object.");
+    }
+
+    public class Ingores
+    {
+        [Test]
+        public void @null() => new Collection.AtLeastAttribute(0).IsValid(null).Should().BeTrue();
+
+        [Test]
+        public void length_zero() => new Collection.AtLeastAttribute(4).IsValid(string.Empty).Should().BeTrue();
+    }
+
+    [Test]
+    public void validates([Range(4, 10)] int value) => new Collection.AtLeastAttribute(4).IsValid(new byte[value]).Should().BeTrue();
+
+    [Test]
+    public void Invalidates([Range(1, 10)] int value) => new Collection.AtLeastAttribute(11).IsValid(new byte[value]).Should().BeFalse();
+
+    [TestCase("nl", "Veld AtLeastProp moet tenminste 4 items bevatten.")]
+    [TestCase("en", "The AtLeastProp field should have at least 4 items.")]
+    public void With_message(CultureInfo culture, string message)
+    {
+        using var _ = culture.Scoped();
+        new Model() {AtLeastProp = "a" }.Should().BeInvalidFor(new AnnotatedModelValidator<Model>())
+            .WithMessage(ValidationMessage.Error(message, "AtLeastProp"));
+    }
+}
+
+public class At_most
+{
+    public class Supports
+    {
+        [Test]
+        public void ICollection() => new Collection.AtMostAttribute(2).IsValid(new[] { 1, 2 }).Should().BeTrue();
+
+        [Test]
+        public void type_with_count_property() => new Collection.AtMostAttribute(40).IsValid(new MyCollection(17)).Should().BeTrue();
+    }
+
+    public class Does_not_support
+    {
+        [Test]
+        public void type_without_count_property()
+            => new Collection.AtMostAttribute(4).Invoking(a => a.IsValid(new object()))
+            .Should().Throw<UnsupportedType>().WithMessage("Collection.AtMostAttribute does not support properties of the type object.");
+    }
+
+    public class Ingores
+    {
+        [Test]
+        public void @null() => new Collection.AtMostAttribute(0).IsValid(null).Should().BeTrue();
+    }
+
+    [Test]
+    public void validates([Range(1, 4)] int value) => new Collection.AtMostAttribute(4).IsValid(new byte[value]).Should().BeTrue();
+
+    [Test]
+    public void Invalidates([Range(12, 20)] int value) => new Collection.AtMostAttribute(11).IsValid(new byte[value]).Should().BeFalse();
+
+    [TestCase("nl", "Veld AtMostProp mag niet meer dan 4 items bevatten.")]
+    [TestCase("en", "The AtMostProp field should have at most 4 items.")]
+    public void With_message(CultureInfo culture, string message)
+    {
+        using var _ = culture.Scoped();
+        new Model() { AtMostProp = "abcde" }.Should().BeInvalidFor(new AnnotatedModelValidator<Model>())
+            .WithMessage(ValidationMessage.Error(message, "AtMostProp"));
+    }
+}
+
+public class In_range
+{
+    public class Supports
+    {
+        [Test]
+        public void ICollection() => new Collection.InRangeAttribute(1, 2).IsValid(new[] { 1, 2 }).Should().BeTrue();
+
+        [Test]
+        public void type_with_count_property() => new Collection.InRangeAttribute(3, 40).IsValid(new MyCollection(17)).Should().BeTrue();
+    }
+
+    public class Does_not_support
+    {
+        [Test]
+        public void type_without_count_property()
+            => new Collection.InRangeAttribute(1, 4).Invoking(a => a.IsValid(new object()))
+            .Should().Throw<UnsupportedType>().WithMessage("Collection.InRangeAttribute does not support properties of the type object.");
+    }
+
+
+    public class Ingores
+    {
+        [Test]
+        public void @null() => new Collection.InRangeAttribute(2, 4).IsValid(null).Should().BeTrue();
+
+        [Test]
+        public void length_zero() => new Collection.InRangeAttribute(2, 4).IsValid(string.Empty).Should().BeTrue();
+    }
+
+
+    [Test]
+    public void validates([Range(4, 10)] int value) => new Collection.InRangeAttribute(4, 10).IsValid(new byte[value]).Should().BeTrue();
+
+    [TestCase(1)]
+    [TestCase(2)]
+    [TestCase(5)]
+    [TestCase(6)]
+    [TestCase(7)]
+    public void Invalidates(int value) => new Collection.InRangeAttribute(3, 4).IsValid(new byte[value]).Should().BeFalse();
+
+    [TestCase("nl", "Het aantal items van veld InRangeProp moet tussen 3 en 4 zitten.")]
+    [TestCase("en", "The number of items of the InRangeProp field should be between 3 and 4.")]
+    public void With_message(CultureInfo culture, string message)
+    {
+        using var _ = culture.Scoped();
+        new Model() { InRangeProp = "a" }.Should().BeInvalidFor(new AnnotatedModelValidator<Model>())
+            .WithMessage(ValidationMessage.Error(message, "InRangeProp"));
+    }
+}
+
+file sealed class Model
+{
+    [Collection.InRange(3, 4)]
+    public string? InRangeProp { get; init; } = "abcd";
+
+    [Collection.AtLeast(4)]
+    public string? AtLeastProp { get; init; } = "abcd";
+
+    [Collection.AtMost(4)]
+    public string? AtMostProp { get; init; } = "abcd";
+}
+
+file sealed record MyCollection(long Count);

--- a/specs/Qowaiv.Validation.Specs/DataAnnotations/Attributes/Length_specs.cs
+++ b/specs/Qowaiv.Validation.Specs/DataAnnotations/Attributes/Length_specs.cs
@@ -26,7 +26,7 @@ public class At_least
             .Should().Throw<UnsupportedType>().WithMessage("Length.AtLeastAttribute does not support properties of the type List<int>.");
     }
 
-    public class Ingores
+    public class Ignores
     {
         [Test]
         public void @null() => new Length.AtLeastAttribute(0).IsValid(null).Should().BeTrue();
@@ -73,7 +73,7 @@ public class At_most
             .Should().Throw<UnsupportedType>().WithMessage("Length.AtMostAttribute does not support properties of the type List<int>.");
     }
 
-    public class Ingores
+    public class Ignores
     {
         [Test]
         public void @null() => new Length.AtMostAttribute(0).IsValid(null).Should().BeTrue();
@@ -118,7 +118,7 @@ public class In_range
     }
 
 
-    public class Ingores
+    public class Ignores
     {
         [Test]
         public void @null() => new Length.InRangeAttribute(2, 4).IsValid(null).Should().BeTrue();
@@ -138,7 +138,7 @@ public class In_range
     [TestCase(7)]
     public void Invalidates(int value) => new Length.InRangeAttribute(3, 4).IsValid(new byte[value]).Should().BeFalse();
 
-    [TestCase("nl", "De lengte van het veld 3 moet tussen de 3 en 4 zijn.")]
+    [TestCase("nl", "De lengte van het veld InRangeProp moet tussen de 3 en 4 zijn.")]
     [TestCase("en", "The length of the InRangeProp field should be between 3 and 4.")]
     public void With_message(CultureInfo culture, string message)
     {

--- a/specs/Qowaiv.Validation.Specs/DataAnnotations/Attributes/Length_specs.cs
+++ b/specs/Qowaiv.Validation.Specs/DataAnnotations/Attributes/Length_specs.cs
@@ -39,11 +39,11 @@ public class At_least
     public void validates([Range(4, 10)] int value) => new Length.AtLeastAttribute(4).IsValid(new byte[value]).Should().BeTrue();
 
     [Test]
-    public void Invalidates([Range(1, 10)] int value) => new Length.AtLeastAttribute(11).IsValid(new byte[value]).Should().BeFalse();
+    public void invalidates([Range(1, 10)] int value) => new Length.AtLeastAttribute(11).IsValid(new byte[value]).Should().BeFalse();
 
     [TestCase("nl", "De lengte van het veld AtLeastProp moet minstens 4 zijn.")]
     [TestCase("en", "The length of the AtLeastProp field should be at least 4.")]
-    public void With_message(CultureInfo culture, string message)
+    public void with_message(CultureInfo culture, string message)
     {
         using var _ = culture.Scoped();
         new Model() {AtLeastProp = "a" }.Should().BeInvalidFor(new AnnotatedModelValidator<Model>())
@@ -83,11 +83,11 @@ public class At_most
     public void validates([Range(1, 4)] int value) => new Length.AtMostAttribute(4).IsValid(new byte[value]).Should().BeTrue();
 
     [Test]
-    public void Invalidates([Range(12, 20)] int value) => new Length.AtMostAttribute(11).IsValid(new byte[value]).Should().BeFalse();
+    public void invalidates([Range(12, 20)] int value) => new Length.AtMostAttribute(11).IsValid(new byte[value]).Should().BeFalse();
 
     [TestCase("nl", "De lengte van het veld AtMostProp mag niet meer dan 4 zijn.")]
     [TestCase("en", "The length of the AtMostProp field should be at most 4.")]
-    public void With_message(CultureInfo culture, string message)
+    public void with_message(CultureInfo culture, string message)
     {
         using var _ = culture.Scoped();
         new Model() { AtMostProp = "abcde" }.Should().BeInvalidFor(new AnnotatedModelValidator<Model>())
@@ -136,11 +136,11 @@ public class In_range
     [TestCase(5)]
     [TestCase(6)]
     [TestCase(7)]
-    public void Invalidates(int value) => new Length.InRangeAttribute(3, 4).IsValid(new byte[value]).Should().BeFalse();
+    public void invalidates(int value) => new Length.InRangeAttribute(3, 4).IsValid(new byte[value]).Should().BeFalse();
 
     [TestCase("nl", "De lengte van het veld InRangeProp moet tussen de 3 en 4 zijn.")]
     [TestCase("en", "The length of the InRangeProp field should be between 3 and 4.")]
-    public void With_message(CultureInfo culture, string message)
+    public void with_message(CultureInfo culture, string message)
     {
         using var _ = culture.Scoped();
         new Model() { InRangeProp = "a" }.Should().BeInvalidFor(new AnnotatedModelValidator<Model>())

--- a/specs/Qowaiv.Validation.Specs/DataAnnotations/Attributes/Length_specs.cs
+++ b/specs/Qowaiv.Validation.Specs/DataAnnotations/Attributes/Length_specs.cs
@@ -1,0 +1,164 @@
+﻿using Qowaiv.Validation.DataAnnotations;
+using System.ComponentModel.DataAnnotations;
+using RangeAttribute = NUnit.Framework.RangeAttribute;
+
+namespace Data_annotations.Attributes.Length_specs;
+
+public class At_least
+{
+    public class Supports
+    {
+        [Test]
+        public void @string() => new Length.AtLeastAttribute(4).IsValid("1234").Should().BeTrue();
+
+        [Test]
+        public void @array() => new Length.AtLeastAttribute(2).IsValid(new int[] { 1, 2 }).Should().BeTrue();
+
+        [Test]
+        public void type_with_length_property() => new Length.AtLeastAttribute(4).IsValid(EmailAddress.Parse("test@qowaiv.org")).Should().BeTrue();
+    }
+
+    public class Does_not_support
+    {
+        [Test]
+        public void type_without_length_property()
+            => new Length.AtLeastAttribute(4).Invoking(a => a.IsValid(new List<int>()))
+            .Should().Throw<UnsupportedType>().WithMessage("Length.AtLeastAttribute does not support properties of the type List<int>.");
+    }
+
+    public class Ingores
+    {
+        [Test]
+        public void @null() => new Length.AtLeastAttribute(0).IsValid(null).Should().BeTrue();
+
+        [Test]
+        public void length_zero() => new Length.AtLeastAttribute(4).IsValid(string.Empty).Should().BeTrue();
+    }
+
+    [Test]
+    public void validates([Range(4, 10)] int value) => new Length.AtLeastAttribute(4).IsValid(new byte[value]).Should().BeTrue();
+
+    [Test]
+    public void Invalidates([Range(1, 10)] int value) => new Length.AtLeastAttribute(11).IsValid(new byte[value]).Should().BeFalse();
+
+    [TestCase("nl", "De lengte van het veld AtLeastProp moet minstens 4 zijn.")]
+    [TestCase("en", "The length of the AtLeastProp field should be at least 4.")]
+    public void With_message(CultureInfo culture, string message)
+    {
+        using var _ = culture.Scoped();
+        new Model() {AtLeastProp = "a" }.Should().BeInvalidFor(new AnnotatedModelValidator<Model>())
+            .WithMessage(ValidationMessage.Error(message, "AtLeastProp"));
+    }
+}
+
+public class At_most
+{
+    public class Supports
+    {
+        [Test]
+        public void @string() => new Length.AtMostAttribute(4).IsValid("1234").Should().BeTrue();
+
+        [Test]
+        public void @array() => new Length.AtMostAttribute(2).IsValid(new int[] { 1, 2 }).Should().BeTrue();
+
+        [Test]
+        public void type_with_length_property() => new Length.AtMostAttribute(40).IsValid(EmailAddress.Parse("test@qowaiv.org")).Should().BeTrue();
+    }
+
+    public class Does_not_support
+    {
+        [Test]
+        public void type_without_length_property()
+            => new Length.AtMostAttribute(4).Invoking(a => a.IsValid(new List<int>()))
+            .Should().Throw<UnsupportedType>().WithMessage("Length.AtMostAttribute does not support properties of the type List<int>.");
+    }
+
+    public class Ingores
+    {
+        [Test]
+        public void @null() => new Length.AtMostAttribute(0).IsValid(null).Should().BeTrue();
+    }
+
+    [Test]
+    public void validates([Range(1, 4)] int value) => new Length.AtMostAttribute(4).IsValid(new byte[value]).Should().BeTrue();
+
+    [Test]
+    public void Invalidates([Range(12, 20)] int value) => new Length.AtMostAttribute(11).IsValid(new byte[value]).Should().BeFalse();
+
+    [TestCase("nl", "De lengte van het veld AtMostProp mag niet meer dan 4 zijn.")]
+    [TestCase("en", "The length of the AtMostProp field should be at most 4.")]
+    public void With_message(CultureInfo culture, string message)
+    {
+        using var _ = culture.Scoped();
+        new Model() { AtMostProp = "abcde" }.Should().BeInvalidFor(new AnnotatedModelValidator<Model>())
+            .WithMessage(ValidationMessage.Error(message, "AtMostProp"));
+    }
+}
+
+public class In_range
+{
+    public class Supports
+    {
+        [Test]
+        public void @string() => new Length.InRangeAttribute(1,4).IsValid("1234").Should().BeTrue();
+
+        [Test]
+        public void @array() => new Length.InRangeAttribute(1, 2).IsValid(new int[] { 1, 2 }).Should().BeTrue();
+
+        [Test]
+        public void type_with_length_property() => new Length.InRangeAttribute(3, 40).IsValid(EmailAddress.Parse("test@qowaiv.org")).Should().BeTrue();
+    }
+
+    public class Does_not_support
+    {
+        [Test]
+        public void type_without_length_property()
+            => new Length.InRangeAttribute(1, 4).Invoking(a => a.IsValid(new List<int>()))
+            .Should().Throw<UnsupportedType>().WithMessage("Length.InRangeAttribute does not support properties of the type List<int>.");
+    }
+
+
+    public class Ingores
+    {
+        [Test]
+        public void @null() => new Length.InRangeAttribute(2, 4).IsValid(null).Should().BeTrue();
+
+        [Test]
+        public void length_zero() => new Length.InRangeAttribute(2, 4).IsValid(string.Empty).Should().BeTrue();
+    }
+
+
+    [Test]
+    public void validates([Range(4, 10)] int value) => new Length.InRangeAttribute(4, 10).IsValid(new byte[value]).Should().BeTrue();
+
+    [TestCase(1)]
+    [TestCase(2)]
+    [TestCase(5)]
+    [TestCase(6)]
+    [TestCase(7)]
+    public void Invalidates(int value) => new Length.InRangeAttribute(3, 4).IsValid(new byte[value]).Should().BeFalse();
+
+    [TestCase("nl", "De lengte van het veld 3 moet tussen de 3 en 4 zijn.")]
+    [TestCase("en", "The length of the InRangeProp field should be between 3 and 4.")]
+    public void With_message(CultureInfo culture, string message)
+    {
+        using var _ = culture.Scoped();
+        new Model() { InRangeProp = "a" }.Should().BeInvalidFor(new AnnotatedModelValidator<Model>())
+            .WithMessage(ValidationMessage.Error(message, "InRangeProp"));
+    }
+}
+
+file sealed class Model
+{
+    [Length(0, 4)]
+    public string? Does_not_conflict_with_System_ComponentModel_DataAnnotations { get; init; }
+
+    [Length.InRange(3, 4)]
+    public string? InRangeProp { get; init; } = "abcd";
+
+    [Length.AtLeast(4)]
+    public string? AtLeastProp { get; init; } = "abcd";
+
+    [Length.AtMost(4)]
+    public string? AtMostProp { get; init; } = "abcd";
+}

--- a/specs/Qowaiv.Validation.Specs/DataAnnotations/Attributes/Size_specs.cs
+++ b/specs/Qowaiv.Validation.Specs/DataAnnotations/Attributes/Size_specs.cs
@@ -28,7 +28,7 @@ public class At_least
             .Should().Throw<UnsupportedType>().WithMessage("Size.AtLeastAttribute does not support properties of the type object.");
     }
 
-    public class Ingores
+    public class Ignores
     {
         [Test]
         public void @null() => new Size.AtLeastAttribute(0).IsValid(null).Should().BeTrue();
@@ -78,7 +78,7 @@ public class At_most
             .Should().Throw<UnsupportedType>().WithMessage("Size.AtMostAttribute does not support properties of the type object.");
     }
 
-    public class Ingores
+    public class Ignores
     {
         [Test]
         public void @null() => new Size.AtMostAttribute(0).IsValid(null).Should().BeTrue();
@@ -126,7 +126,7 @@ public class In_range
     }
 
 
-    public class Ingores
+    public class Ignores
     {
         [Test]
         public void @null() => new Size.InRangeAttribute(2, 4).IsValid(null).Should().BeTrue();
@@ -146,7 +146,7 @@ public class In_range
     [TestCase(7)]
     public void Invalidates(int value) => new Size.InRangeAttribute(3, 4).IsValid(new byte[value]).Should().BeFalse();
 
-    [TestCase("nl", "De grootte van het veld 3 moet tussen de 3 byte en 4 byte zijn.")]
+    [TestCase("nl", "De grootte van het veld InRangeProp moet tussen de 3 byte en 4 byte zijn.")]
     [TestCase("en", "The size of the InRangeProp field should be between 3 byte and 4 byte.")]
     public void With_message(CultureInfo culture, string message)
     {

--- a/specs/Qowaiv.Validation.Specs/DataAnnotations/Attributes/Size_specs.cs
+++ b/specs/Qowaiv.Validation.Specs/DataAnnotations/Attributes/Size_specs.cs
@@ -41,11 +41,11 @@ public class At_least
     public void validates([Range(4, 10)] int value) => new Size.AtLeastAttribute(4).IsValid(new byte[value]).Should().BeTrue();
 
     [Test]
-    public void Invalidates([Range(1, 10)] int value) => new Size.AtLeastAttribute(11).IsValid(new byte[value]).Should().BeFalse();
+    public void invalidates([Range(1, 10)] int value) => new Size.AtLeastAttribute(11).IsValid(new byte[value]).Should().BeFalse();
 
     [TestCase("nl", "De grootte van het veld AtLeastProp moet minstens 4 byte zijn.")]
     [TestCase("en", "The size of the AtLeastProp field should be at least 4 byte.")]
-    public void With_message(CultureInfo culture, string message)
+    public void with_message(CultureInfo culture, string message)
     {
         using var _ = culture.Scoped();
         new Model() {AtLeastProp = new([1, 2]) }.Should().BeInvalidFor(new AnnotatedModelValidator<Model>())
@@ -88,11 +88,11 @@ public class At_most
     public void validates([Range(1, 4)] int value) => new Size.AtMostAttribute(4).IsValid(new byte[value]).Should().BeTrue();
 
     [Test]
-    public void Invalidates([Range(12, 20)] int value) => new Size.AtMostAttribute(11).IsValid(new byte[value]).Should().BeFalse();
+    public void invalidates([Range(12, 20)] int value) => new Size.AtMostAttribute(11).IsValid(new byte[value]).Should().BeFalse();
 
     [TestCase("nl", "De grootte van het veld AtMostProp mag niet meer dan 4 byte zijn.")]
     [TestCase("en", "The size of the AtMostProp field should be at most 4 byte.")]
-    public void With_message(CultureInfo culture, string message)
+    public void with_message(CultureInfo culture, string message)
     {
         using var _ = culture.Scoped();
         new Model() { AtMostProp = new([1, 2, 3, 4, 5]) }.Should().BeInvalidFor(new AnnotatedModelValidator<Model>())
@@ -144,11 +144,11 @@ public class In_range
     [TestCase(5)]
     [TestCase(6)]
     [TestCase(7)]
-    public void Invalidates(int value) => new Size.InRangeAttribute(3, 4).IsValid(new byte[value]).Should().BeFalse();
+    public void invalidates(int value) => new Size.InRangeAttribute(3, 4).IsValid(new byte[value]).Should().BeFalse();
 
     [TestCase("nl", "De grootte van het veld InRangeProp moet tussen de 3 byte en 4 byte zijn.")]
     [TestCase("en", "The size of the InRangeProp field should be between 3 byte and 4 byte.")]
-    public void With_message(CultureInfo culture, string message)
+    public void with_message(CultureInfo culture, string message)
     {
         using var _ = culture.Scoped();
         new Model() { InRangeProp = new([1, 2]) }.Should().BeInvalidFor(new AnnotatedModelValidator<Model>())

--- a/specs/Qowaiv.Validation.Specs/DataAnnotations/Attributes/Size_specs.cs
+++ b/specs/Qowaiv.Validation.Specs/DataAnnotations/Attributes/Size_specs.cs
@@ -90,8 +90,8 @@ public class At_most
     [Test]
     public void Invalidates([Range(12, 20)] int value) => new Size.AtMostAttribute(11).IsValid(new byte[value]).Should().BeFalse();
 
-    [TestCase("nl", "The AtMostProp field should have at most 4 items.")]
-    [TestCase("en", "De grootte van het veld AtMostProp mag niet meer dan 4 byte zijn.")]
+    [TestCase("en", "The AtMostProp field should have at most 4 items.")]
+    [TestCase("nl", "De grootte van het veld AtMostProp mag niet meer dan 4 byte zijn.")]
     public void With_message(CultureInfo culture, string message)
     {
         using var _ = culture.Scoped();

--- a/specs/Qowaiv.Validation.Specs/DataAnnotations/Attributes/Size_specs.cs
+++ b/specs/Qowaiv.Validation.Specs/DataAnnotations/Attributes/Size_specs.cs
@@ -1,0 +1,178 @@
+﻿using Qowaiv.Validation.DataAnnotations;
+using RangeAttribute = NUnit.Framework.RangeAttribute;
+
+namespace Data_annotations.Attributes.Size_specs;
+
+public class At_least
+{
+    public class Supports
+    {
+        [Test]
+        public void Stream() => new Size.AtLeastAttribute(2).IsValid(System.IO.Stream.Null).Should().BeTrue();
+
+        [Test]
+        public void ICollection_Byte() => new Size.AtLeastAttribute(2).IsValid(Array.Empty<byte>()).Should().BeTrue();
+
+        [Test]
+        public void IReadOnlyCollection_Byte() => new Size.AtLeastAttribute(2).IsValid(new ReadOnlyByteArray()).Should().BeTrue();
+
+        [Test]
+        public void BinaryData() => new Size.AtLeastAttribute(2).IsValid(new BinaryData([1, 2])).Should().BeTrue();
+    }
+
+    public class Does_not_support
+    {
+        [Test]
+        public void type_without_count_property()
+            => new Size.AtLeastAttribute(4).Invoking(a => a.IsValid(new object()))
+            .Should().Throw<UnsupportedType>().WithMessage("Size.AtLeastAttribute does not support properties of the type object.");
+    }
+
+    public class Ingores
+    {
+        [Test]
+        public void @null() => new Size.AtLeastAttribute(0).IsValid(null).Should().BeTrue();
+
+        [Test]
+        public void length_zero() => new Size.AtLeastAttribute(4).IsValid(System.IO.Stream.Null).Should().BeTrue();
+    }
+
+    [Test]
+    public void validates([Range(4, 10)] int value) => new Size.AtLeastAttribute(4).IsValid(new byte[value]).Should().BeTrue();
+
+    [Test]
+    public void Invalidates([Range(1, 10)] int value) => new Size.AtLeastAttribute(11).IsValid(new byte[value]).Should().BeFalse();
+
+    [TestCase("nl", "De grootte van het veld AtLeastProp moet minstens 4 byte zijn.")]
+    [TestCase("en", "The size of the AtLeastProp field should be at least 4 byte.")]
+    public void With_message(CultureInfo culture, string message)
+    {
+        using var _ = culture.Scoped();
+        new Model() {AtLeastProp = new([1, 2]) }.Should().BeInvalidFor(new AnnotatedModelValidator<Model>())
+            .WithMessage(ValidationMessage.Error(message, "AtLeastProp"));
+    }
+}
+
+public class At_most
+{
+    public class Supports
+    {
+        [Test]
+        public void Stream() => new Size.AtMostAttribute(2).IsValid(System.IO.Stream.Null).Should().BeTrue();
+
+        [Test]
+        public void ICollection_Byte() => new Size.AtMostAttribute(2).IsValid(Array.Empty<byte>()).Should().BeTrue();
+
+        [Test]
+        public void IReadOnlyCollection_Byte() => new Size.AtMostAttribute(2).IsValid(new ReadOnlyByteArray()).Should().BeTrue();
+
+        [Test]
+        public void BinaryData() => new Size.AtMostAttribute(2).IsValid(new BinaryData([1, 2])).Should().BeTrue();
+    }
+
+    public class Does_not_support
+    {
+        [Test]
+        public void type_without_count_property()
+            => new Size.AtMostAttribute(4).Invoking(a => a.IsValid(new object()))
+            .Should().Throw<UnsupportedType>().WithMessage("Size.AtMostAttribute does not support properties of the type object.");
+    }
+
+    public class Ingores
+    {
+        [Test]
+        public void @null() => new Size.AtMostAttribute(0).IsValid(null).Should().BeTrue();
+    }
+
+    [Test]
+    public void validates([Range(1, 4)] int value) => new Size.AtMostAttribute(4).IsValid(new byte[value]).Should().BeTrue();
+
+    [Test]
+    public void Invalidates([Range(12, 20)] int value) => new Size.AtMostAttribute(11).IsValid(new byte[value]).Should().BeFalse();
+
+    [TestCase("nl", "The AtMostProp field should have at most 4 items.")]
+    [TestCase("en", "De grootte van het veld AtMostProp mag niet meer dan 4 byte zijn.")]
+    public void With_message(CultureInfo culture, string message)
+    {
+        using var _ = culture.Scoped();
+        new Model() { AtMostProp = new([1, 2, 3, 4, 5]) }.Should().BeInvalidFor(new AnnotatedModelValidator<Model>())
+            .WithMessage(ValidationMessage.Error(message, "AtMostProp"));
+    }
+}
+
+public class In_range
+{
+    public class Supports
+    {
+        [Test]
+        public void Stream() => new Size.InRangeAttribute(2, 4).IsValid(System.IO.Stream.Null).Should().BeTrue();
+
+        [Test]
+        public void ICollection_Byte() => new Size.InRangeAttribute(2, 4).IsValid(Array.Empty<byte>()).Should().BeTrue();
+
+        [Test]
+        public void IReadOnlyCollection_Byte() => new Size.InRangeAttribute(2, 4).IsValid(new ReadOnlyByteArray()).Should().BeTrue();
+
+        [Test]
+        public void BinaryData() => new Size.InRangeAttribute(2, 4).IsValid(new BinaryData([1, 2])).Should().BeTrue();
+    }
+
+    public class Does_not_support
+    {
+        [Test]
+        public void type_without_count_property()
+            => new Size.InRangeAttribute(1, 4).Invoking(a => a.IsValid(new object()))
+            .Should().Throw<UnsupportedType>().WithMessage("Size.InRangeAttribute does not support properties of the type object.");
+    }
+
+
+    public class Ingores
+    {
+        [Test]
+        public void @null() => new Size.InRangeAttribute(2, 4).IsValid(null).Should().BeTrue();
+
+        [Test]
+        public void length_zero() => new Size.InRangeAttribute(2, 4).IsValid(System.IO.Stream.Null).Should().BeTrue();
+    }
+
+
+    [Test]
+    public void validates([Range(4, 10)] int value) => new Size.InRangeAttribute(4, 10).IsValid(new byte[value]).Should().BeTrue();
+
+    [TestCase(1)]
+    [TestCase(2)]
+    [TestCase(5)]
+    [TestCase(6)]
+    [TestCase(7)]
+    public void Invalidates(int value) => new Size.InRangeAttribute(3, 4).IsValid(new byte[value]).Should().BeFalse();
+
+    [TestCase("nl", "De grootte van het veld 3 moet tussen de 3 byte en 4 byte zijn.")]
+    [TestCase("en", "The size of the InRangeProp field should be between 3 byte and 4 byte.")]
+    public void With_message(CultureInfo culture, string message)
+    {
+        using var _ = culture.Scoped();
+        new Model() { InRangeProp = new([1, 2]) }.Should().BeInvalidFor(new AnnotatedModelValidator<Model>())
+            .WithMessage(ValidationMessage.Error(message, "InRangeProp"));
+    }
+}
+
+file sealed class Model
+{
+    [Size.InRange(3, 4)]
+    public BinaryData InRangeProp { get; init; } = new([1, 2, 3, 4]);
+
+    [Size.AtLeast(4)]
+    public BinaryData AtLeastProp { get; init; } = new([1, 2, 3, 4]);
+
+    [Size.AtMost(4)]
+    public BinaryData AtMostProp { get; init; } = new([1, 2, 3, 4]);
+}
+
+file sealed class ReadOnlyByteArray : IReadOnlyCollection<byte>
+{
+    public int Count => 0;
+
+    public IEnumerator<byte> GetEnumerator(){ yield break; }
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/specs/Qowaiv.Validation.Specs/DataAnnotations/Attributes/Size_specs.cs
+++ b/specs/Qowaiv.Validation.Specs/DataAnnotations/Attributes/Size_specs.cs
@@ -90,8 +90,8 @@ public class At_most
     [Test]
     public void Invalidates([Range(12, 20)] int value) => new Size.AtMostAttribute(11).IsValid(new byte[value]).Should().BeFalse();
 
-    [TestCase("en", "The AtMostProp field should have at most 4 items.")]
     [TestCase("nl", "De grootte van het veld AtMostProp mag niet meer dan 4 byte zijn.")]
+    [TestCase("en", "The size of the AtMostProp field should be at most 4 byte.")]
     public void With_message(CultureInfo culture, string message)
     {
         using var _ = culture.Scoped();

--- a/specs/Qowaiv.Validation.Specs/Qowaiv.Validation.Specs.csproj
+++ b/specs/Qowaiv.Validation.Specs/Qowaiv.Validation.Specs.csproj
@@ -43,6 +43,7 @@
   <ItemGroup Label="Analyzers">
     <PackageReference Include="FluentAssertions.Analyzers" Version="*" PrivateAssets="all" />
     <PackageReference Include="NUnit.Analyzers" Version="*" PrivateAssets="all" />
+    <PackageReference Include="System.Memory.Data" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/Collection.AtLeastAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/Collection.AtLeastAttribute.cs
@@ -1,12 +1,12 @@
 ﻿namespace Qowaiv.Validation.DataAnnotations;
 
-/// <summary>Validation attributes on the length of a value.</summary>
-public static partial class Length
+/// <summary>Validation attributes on the size of the collection.</summary>
+public static partial class Collection
 {
     /// <summary>Specifies the minimum the length of property, field or parameter.</summary>
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
     public sealed class AtLeastAttribute(long minimum)
-        : ValidationAttribute(() => QowaivValidationMessages.Length_AtLeast_ValdationError)
+        : ValidationAttribute(() => QowaivValidationMessages.Collection_AtLeast_ValdationError)
     {
         /// <summary>The minimum length.</summary>
         public long Minimum { get; } = minimum;
@@ -14,13 +14,13 @@ public static partial class Length
         /// <inheritdoc />
         [Pure]
         public override bool IsValid(object? value)
-            => GetLength<AtLeastAttribute>(value) is not long length
-            || length == 0
-            || length >= Minimum;
+            => GetCount<AtLeastAttribute>(value) is not long count
+            || count == 0
+            || count >= Minimum;
 
         /// <inheritdoc />
         [Pure]
         public override string FormatErrorMessage(string name)
-            => string.Format(CultureInfo.CurrentCulture, ErrorMessageString, name, Minimum);
+                => string.Format(CultureInfo.CurrentCulture, ErrorMessageString, name, Minimum);
     }
 }

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/Collection.AtLeastAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/Collection.AtLeastAttribute.cs
@@ -15,7 +15,7 @@ public static partial class Collection
         [Pure]
         public override bool IsValid(object? value)
             => GetCount<AtLeastAttribute>(value) is not long count
-            || count == 0
+            || count == 0 // should be dealt with by mandatory/required.
             || count >= Minimum;
 
         /// <inheritdoc />

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/Collection.AtLeastAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/Collection.AtLeastAttribute.cs
@@ -6,7 +6,7 @@ public static partial class Collection
     /// <summary>Specifies the minimum the length of property, field or parameter.</summary>
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
     public sealed class AtLeastAttribute(long minimum)
-        : ValidationAttribute(() => QowaivValidationMessages.Collection_AtLeast_ValdationError)
+        : ValidationAttribute(() => QowaivValidationMessages.Collection_AtLeast_ValidationError)
     {
         /// <summary>The minimum length.</summary>
         public long Minimum { get; } = minimum;

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/Collection.AtMostAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/Collection.AtMostAttribute.cs
@@ -1,21 +1,21 @@
 ﻿namespace Qowaiv.Validation.DataAnnotations;
 
-/// <summary>Validation attributes on the length of a value.</summary>
-public static partial class Length
+/// <summary>Validation attributes on the size of the collection.</summary>
+public static partial class Collection
 {
     /// <summary>Specifies the maximum the length of property, field or parameter.</summary>
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
     public sealed class AtMostAttribute(long maximum)
-        : ValidationAttribute(() => QowaivValidationMessages.Length_AtMost_ValidationError)
+        : ValidationAttribute(() => QowaivValidationMessages.Collection_AtMost_ValidationError)
     {
         /// <summary>The maximum length.</summary>
         public long Maximum { get; } = maximum;
 
         /// <inheritdoc />
         [Pure]
-        public override bool IsValid(object? value) 
-            => GetLength<AtMostAttribute>(value) is not long length
-            || length <= Maximum;
+        public override bool IsValid(object? value)
+            => GetCount<AtMostAttribute>(value) is not long count
+            || count <= Maximum;
 
         /// <inheritdoc />
         [Pure]

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/Collection.InRangeAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/Collection.InRangeAttribute.cs
@@ -1,12 +1,12 @@
 ﻿namespace Qowaiv.Validation.DataAnnotations;
 
-/// <summary>Validation attributes on the length of a value.</summary>
-public static partial class Length
+/// <summary>Validation attributes on the size of the collection.</summary>
+public static partial class Collection
 {
     /// <summary>Specifies the allowed range of the length of property, field or parameter.</summary>
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
     public sealed class InRangeAttribute(long minimum, long maximum)
-        : ValidationAttribute(() => QowaivValidationMessages.Length_InRange_ValidationError)
+        : ValidationAttribute(() => QowaivValidationMessages.Collection_InRange_ValidationError)
     {
         /// <summary>The minimum length.</summary>
         public long Minimum { get; } = minimum;
@@ -17,13 +17,13 @@ public static partial class Length
         /// <inheritdoc />
         [Pure]
         public override bool IsValid(object? value)
-            => GetLength<InRangeAttribute>(value) is not long length
-            || length == 0
-            || (length >= Minimum && length <= Maximum);
+            => GetCount<InRangeAttribute>(value) is not long count
+            || count == 0
+            || (count >= Minimum && count <= Maximum);
 
         /// <inheritdoc />
         [Pure]
         public override string FormatErrorMessage(string name)
-            => string.Format(CultureInfo.CurrentCulture, ErrorMessageString, name, Minimum, Maximum);
+                => string.Format(CultureInfo.CurrentCulture, ErrorMessageString, name, Minimum, Maximum);
     }
 }

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/Collection.InRangeAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/Collection.InRangeAttribute.cs
@@ -18,7 +18,7 @@ public static partial class Collection
         [Pure]
         public override bool IsValid(object? value)
             => GetCount<InRangeAttribute>(value) is not long count
-            || count == 0
+            || count == 0 // should be dealt with by mandatory/required.
             || (count >= Minimum && count <= Maximum);
 
         /// <inheritdoc />

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/Collection.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/Collection.cs
@@ -1,0 +1,16 @@
+﻿using Qowaiv.Validation.DataAnnotations.Reflection;
+
+namespace Qowaiv.Validation.DataAnnotations;
+
+/// <summary>Validation attributes on the size of the collection.</summary>
+public static partial class Collection
+{
+    [Pure]
+    private static long? GetCount<TAttribute>(object? value) where TAttribute : ValidationAttribute => value switch
+    {
+        null => null,
+        ICollection collection => collection.Count,
+        _ when value.TryCount() is { } count => count,
+        _ => throw UnsupportedType.ForAttribute<TAttribute>(value.GetType()),
+    };
+}

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/Length.AtLeastAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/Length.AtLeastAttribute.cs
@@ -15,7 +15,7 @@ public static partial class Length
         [Pure]
         public override bool IsValid(object? value)
             => GetLength<AtLeastAttribute>(value) is not long length
-            || length == 0
+            || length == 0 // should be dealt with by mandatory/required.
             || length >= Minimum;
 
         /// <inheritdoc />

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/Length.AtLeastAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/Length.AtLeastAttribute.cs
@@ -1,0 +1,24 @@
+﻿namespace Qowaiv.Validation.DataAnnotations;
+
+public static partial class Length
+{
+    /// <summary>Specifies the minimum the length of property, field or parameter.</summary>
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
+    public sealed class AtLeast(long minimum)
+        : ValidationAttribute(() => QowaivValidationMessages.Length_AtLeast_ValdationError)
+    {
+        /// <summary>The minimum length.</summary>
+        public long Minimum { get; } = minimum;
+
+        /// <inheritdoc />
+        [Pure]
+        public override bool IsValid(object? value)
+            => GetLength(value) is not long length
+            || length >= Minimum;
+
+        /// <inheritdoc />
+        [Pure]
+        public override string FormatErrorMessage(string name)
+            => string.Format(CultureInfo.CurrentCulture, ErrorMessageString, name, Minimum);
+    }
+}

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/Length.AtLeastAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/Length.AtLeastAttribute.cs
@@ -6,7 +6,7 @@ public static partial class Length
     /// <summary>Specifies the minimum the length of property, field or parameter.</summary>
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
     public sealed class AtLeastAttribute(long minimum)
-        : ValidationAttribute(() => QowaivValidationMessages.Length_AtLeast_ValdationError)
+        : ValidationAttribute(() => QowaivValidationMessages.Length_AtLeast_ValidationError)
     {
         /// <summary>The minimum length.</summary>
         public long Minimum { get; } = minimum;

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/Length.AtMostAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/Length.AtMostAttribute.cs
@@ -1,0 +1,24 @@
+﻿namespace Qowaiv.Validation.DataAnnotations;
+
+public static partial class Length
+{
+    /// <summary>Specifies the maximum the length of property, field or parameter.</summary>
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
+    public sealed class AtMost(long maximum)
+        : ValidationAttribute(() => QowaivValidationMessages.Length_AtMost_ValidationError)
+    {
+        /// <summary>The maximum length.</summary>
+        public long Maximum { get; } = maximum;
+
+        /// <inheritdoc />
+        [Pure]
+        public override bool IsValid(object? value)
+            => GetLength(value) is not long length
+            || length <= Maximum;
+
+        /// <inheritdoc />
+        [Pure]
+        public override string FormatErrorMessage(string name)
+            => string.Format(CultureInfo.CurrentCulture, ErrorMessageString, name, Maximum);
+    }
+}

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/Length.InRangeAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/Length.InRangeAttribute.cs
@@ -18,7 +18,7 @@ public static partial class Length
         [Pure]
         public override bool IsValid(object? value)
             => GetLength<InRangeAttribute>(value) is not long length
-            || length == 0
+            || length == 0 // should be dealt with by mandatory/required.
             || (length >= Minimum && length <= Maximum);
 
         /// <inheritdoc />

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/Length.InRangeAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/Length.InRangeAttribute.cs
@@ -1,0 +1,28 @@
+﻿namespace Qowaiv.Validation.DataAnnotations;
+
+/// <summary>Validation attributes on the length of a value.</summary>
+public static partial class Length
+{
+    /// <summary>Specifies the allowed range of the length of property, field or parameter.</summary>
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
+    public sealed class InRangeAttribute(int minimum, int maximum)
+        : ValidationAttribute(() => QowaivValidationMessages.Length_InRange_ValidationError)
+    {
+        /// <summary>The minimum length.</summary>
+        public long Minimum { get; } = minimum;
+
+        /// <summary>The maximum length.</summary>
+        public long Maximum { get; } = maximum;
+
+        /// <inheritdoc />
+        [Pure]
+        public override bool IsValid(object? value)
+            => GetLength(value) is not long length
+            || (length >= Minimum && length <= Maximum);
+
+        /// <inheritdoc />
+        [Pure]
+        public override string FormatErrorMessage(string name)
+            => string.Format(CultureInfo.CurrentCulture, ErrorMessageString, name, Minimum, Maximum);
+    }
+}

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/Length.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/Length.cs
@@ -1,0 +1,29 @@
+﻿using System.Reflection;
+
+namespace Qowaiv.Validation.DataAnnotations;
+
+/// <summary>Validation attributes on the length of a value.</summary>
+public static partial class Length
+{
+    [Pure]
+    private static long? GetLength(object? value) => value switch
+    {
+        null => null,
+        ICollection collection => collection.Count,
+        _ => Try("Count", value) ?? Try("Length", value),
+    };
+
+    [Pure]
+    private static long? Try(string name,  object value)
+        => value.GetType().GetRuntimeProperty("name") is { CanRead: true } prop
+            ? GetValue(value, prop)
+            : null;
+
+    [Pure]
+    private static long? GetValue(object value, PropertyInfo property) => property.PropertyType switch
+    {
+        var type when type == typeof(int) => (int?)property.GetValue(value),
+        var type when type == typeof(long) => (long?)property.GetValue(value),
+        _ => null,
+    };
+}

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/Length.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/Length.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+﻿using Qowaiv.Validation.DataAnnotations.Reflection;
 
 namespace Qowaiv.Validation.DataAnnotations;
 
@@ -6,24 +6,12 @@ namespace Qowaiv.Validation.DataAnnotations;
 public static partial class Length
 {
     [Pure]
-    private static long? GetLength(object? value) => value switch
+    private static long? GetLength<TAttribute>(object? value) where TAttribute : ValidationAttribute => value switch
     {
         null => null,
-        ICollection collection => collection.Count,
-        _ => Try("Count", value) ?? Try("Length", value),
-    };
-
-    [Pure]
-    private static long? Try(string name,  object value)
-        => value.GetType().GetRuntimeProperty("name") is { CanRead: true } prop
-            ? GetValue(value, prop)
-            : null;
-
-    [Pure]
-    private static long? GetValue(object value, PropertyInfo property) => property.PropertyType switch
-    {
-        var type when type == typeof(int) => (int?)property.GetValue(value),
-        var type when type == typeof(long) => (long?)property.GetValue(value),
-        _ => null,
+        string str => str.Length,
+        Array array => array.LongLength,
+        _ when value.TryLength() is { } length => length,
+        _ => throw UnsupportedType.ForAttribute<TAttribute>(value.GetType()),
     };
 }

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/Size.AtLeastAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/Size.AtLeastAttribute.cs
@@ -8,7 +8,7 @@ public static partial class Size
     /// <summary>Specifies the minimum the size of property, field or parameter.</summary>
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
     public sealed class AtLeastAttribute(long minimum)
-        : ValidationAttribute(() => QowaivValidationMessages.Size_AtLeast_ValdationError)
+        : ValidationAttribute(() => QowaivValidationMessages.Size_AtLeast_ValidationError)
     {
         /// <summary>Initializes a new instance of the <see cref="AtLeastAttribute"/> class.</summary>
         public AtLeastAttribute(string minimum)

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/Size.AtLeastAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/Size.AtLeastAttribute.cs
@@ -21,7 +21,7 @@ public static partial class Size
         [Pure]
         public override bool IsValid(object? value)
             => GetSize<AtLeastAttribute>(value) is not StreamSize size
-            || size == StreamSize.Zero
+            || size == StreamSize.Zero // should be dealt with by mandatory/required.
             || size >= Minimum;
 
         /// <inheritdoc />

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/Size.AtLeastAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/Size.AtLeastAttribute.cs
@@ -1,0 +1,32 @@
+﻿using Qowaiv.IO;
+
+namespace Qowaiv.Validation.DataAnnotations;
+
+/// <summary>Validation attributes on the size of a value.</summary>
+public static partial class Size
+{
+    /// <summary>Specifies the minimum the size of property, field or parameter.</summary>
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
+    public sealed class AtLeastAttribute(long minimum)
+        : ValidationAttribute(() => QowaivValidationMessages.Size_AtLeast_ValdationError)
+    {
+        /// <summary>Initializes a new instance of the <see cref="AtLeastAttribute"/> class.</summary>
+        public AtLeastAttribute(string minimum)
+            : this((long)StreamSize.Parse(minimum, CultureInfo.InvariantCulture)) { }
+
+        /// <summary>The minimum size.</summary>
+        public StreamSize Minimum { get; } = minimum;
+
+        /// <inheritdoc />
+        [Pure]
+        public override bool IsValid(object? value)
+            => GetSize<AtLeastAttribute>(value) is not StreamSize size
+            || size == StreamSize.Zero
+            || size >= Minimum;
+
+        /// <inheritdoc />
+        [Pure]
+        public override string FormatErrorMessage(string name)
+            => string.Format(CultureInfo.CurrentCulture, ErrorMessageString, name, Minimum);
+    }
+}

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/Size.AtMostAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/Size.AtMostAttribute.cs
@@ -1,0 +1,31 @@
+﻿using Qowaiv.IO;
+
+namespace Qowaiv.Validation.DataAnnotations;
+
+/// <summary>Validation attributes on the size of a value.</summary>
+public static partial class Size
+{
+    /// <summary>Specifies the maximum the length of property, field or parameter.</summary>
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
+    public sealed class AtMostAttribute(long maximum)
+        : ValidationAttribute(() => QowaivValidationMessages.Size_AtMost_ValidationError)
+    {
+        /// <summary>Initializes a new instance of the <see cref="AtMostAttribute"/> class.</summary>
+        public AtMostAttribute(string minimum)
+            : this((long)StreamSize.Parse(minimum, CultureInfo.InvariantCulture)) { }
+
+        /// <summary>The maximum length.</summary>
+        public StreamSize Maximum { get; } = maximum;
+
+        /// <inheritdoc />
+        [Pure]
+        public override bool IsValid(object? value)
+            => GetSize<AtMostAttribute>(value) is not StreamSize size
+            || size <= Maximum;
+
+        /// <inheritdoc />
+        [Pure]
+        public override string FormatErrorMessage(string name)
+            => string.Format(CultureInfo.CurrentCulture, ErrorMessageString, name, Maximum);
+    }
+}

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/Size.InRangeAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/Size.InRangeAttribute.cs
@@ -25,7 +25,7 @@ public static partial class Size
         [Pure]
         public override bool IsValid(object? value)
             => GetSize<InRangeAttribute>(value) is not StreamSize size
-            || size == StreamSize.Zero
+            || size == StreamSize.Zero // should be dealt with by mandatory/required.
             || (size >= Minimum && size <= Maximum);
 
         /// <inheritdoc />

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/Size.InRangeAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/Size.InRangeAttribute.cs
@@ -1,0 +1,36 @@
+﻿using Qowaiv.IO;
+
+namespace Qowaiv.Validation.DataAnnotations;
+
+/// <summary>Validation attributes on the size of a value.</summary>
+public static partial class Size
+{
+    /// <summary>Specifies the allowed range of the size of property, field or parameter.</summary>
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
+    public sealed class InRangeAttribute(long minimum, long maximum)
+        : ValidationAttribute(() => QowaivValidationMessages.Size_InRange_ValidationError)
+    {
+        /// <summary>Initializes a new instance of the <see cref="InRangeAttribute"/> class.</summary>
+        public InRangeAttribute(string minimum, string maximum) : this(
+            (long)StreamSize.Parse(minimum, CultureInfo.InvariantCulture),
+            (long)StreamSize.Parse(maximum, CultureInfo.InvariantCulture)) { }
+
+        /// <summary>The minimum length.</summary>
+        public StreamSize Minimum { get; } = minimum;
+
+        /// <summary>The maximum length.</summary>
+        public StreamSize Maximum { get; } = maximum;
+
+        /// <inheritdoc />
+        [Pure]
+        public override bool IsValid(object? value)
+            => GetSize<InRangeAttribute>(value) is not StreamSize size
+            || size == StreamSize.Zero
+            || (size >= Minimum && size <= Maximum);
+
+        /// <inheritdoc />
+        [Pure]
+        public override string FormatErrorMessage(string name)
+            => string.Format(CultureInfo.CurrentCulture, ErrorMessageString, name, Minimum, Maximum);
+    }
+}

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/Size.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/Size.cs
@@ -1,0 +1,20 @@
+﻿using Qowaiv.IO;
+using Qowaiv.Validation.DataAnnotations.Reflection;
+using System.IO;
+
+namespace Qowaiv.Validation.DataAnnotations;
+
+/// <summary>Validation attributes on the size of a value.</summary>
+public static partial class Size
+{
+    [Pure]
+    private static StreamSize? GetSize<TAttribute>(object? value) where TAttribute : ValidationAttribute => value switch
+    {
+        null => null,
+        Stream stream => stream.GetStreamSize(),
+        ICollection<byte> collection => collection.Count,
+        IReadOnlyCollection<byte> collection => collection.Count,
+        _ when value.GetType().FullName == "System.BinaryData" => value.TryLength()!.Value,
+        _ => throw UnsupportedType.ForAttribute<TAttribute>(value.GetType()),
+    };
+}

--- a/src/Qowaiv.Validation.DataAnnotations/Qowaiv.Validation.DataAnnotations.csproj
+++ b/src/Qowaiv.Validation.DataAnnotations/Qowaiv.Validation.DataAnnotations.csproj
@@ -9,6 +9,9 @@
     <PackageReleaseNotes>
 ToBeReleased
 - Introduction of [IsFinite] validation attribute.
+- Introduction of [Length.AtLeast], [Length.AtMost], [Length.InRange].
+- Introduction of [Collection.AtLeast], [Collection.AtMost], [Collection.InRange].
+- Introduction of [Size.AtLeast], [Size.AtMost], [Size.InRange].
 v1.4.0
 - Introduced [MultipleOf] validation attribute. #69
 - Marked [NestedModel] attribute as obsolete. #70

--- a/src/Qowaiv.Validation.DataAnnotations/QowaivValidationMessages.Designer.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/QowaivValidationMessages.Designer.cs
@@ -81,9 +81,9 @@ namespace Qowaiv.Validation.DataAnnotations {
         /// <summary>
         ///   Looks up a localized string similar to The {0} field should have at least {1} items..
         /// </summary>
-        internal static string Collection_AtLeast_ValdationError {
+        internal static string Collection_AtLeast_ValidationError {
             get {
-                return ResourceManager.GetString("Collection_AtLeast_ValdationError", resourceCulture);
+                return ResourceManager.GetString("Collection_AtLeast_ValidationError", resourceCulture);
             }
         }
         
@@ -126,9 +126,9 @@ namespace Qowaiv.Validation.DataAnnotations {
         /// <summary>
         ///   Looks up a localized string similar to The length of the {0} field should be at least {1}..
         /// </summary>
-        internal static string Length_AtLeast_ValdationError {
+        internal static string Length_AtLeast_ValidationError {
             get {
-                return ResourceManager.GetString("Length_AtLeast_ValdationError", resourceCulture);
+                return ResourceManager.GetString("Length_AtLeast_ValidationError", resourceCulture);
             }
         }
         
@@ -171,9 +171,9 @@ namespace Qowaiv.Validation.DataAnnotations {
         /// <summary>
         ///   Looks up a localized string similar to The size of the {0} field should be at least {1: F}..
         /// </summary>
-        internal static string Size_AtLeast_ValdationError {
+        internal static string Size_AtLeast_ValidationError {
             get {
-                return ResourceManager.GetString("Size_AtLeast_ValdationError", resourceCulture);
+                return ResourceManager.GetString("Size_AtLeast_ValidationError", resourceCulture);
             }
         }
         
@@ -198,9 +198,9 @@ namespace Qowaiv.Validation.DataAnnotations {
         /// <summary>
         ///   Looks up a localized string similar to {0} does not support properties of the type {1}..
         /// </summary>
-        internal static string UnsupportedProperyType_For {
+        internal static string UnsupportedType_ForAttribute {
             get {
-                return ResourceManager.GetString("UnsupportedProperyType_For", resourceCulture);
+                return ResourceManager.GetString("UnsupportedType_ForAttribute", resourceCulture);
             }
         }
     }

--- a/src/Qowaiv.Validation.DataAnnotations/QowaivValidationMessages.Designer.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/QowaivValidationMessages.Designer.cs
@@ -97,6 +97,33 @@ namespace Qowaiv.Validation.DataAnnotations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The length of the {0} field should be at least {1}..
+        /// </summary>
+        internal static string Length_AtLeast_ValdationError {
+            get {
+                return ResourceManager.GetString("Length_AtLeast_ValdationError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The length of the {0} field should be at most {1}..
+        /// </summary>
+        internal static string Length_AtMost_ValidationError {
+            get {
+                return ResourceManager.GetString("Length_AtMost_ValidationError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The length of the {0} field should be between {1} and {2}..
+        /// </summary>
+        internal static string Length_InRange_ValidationError {
+            get {
+                return ResourceManager.GetString("Length_InRange_ValidationError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The {0} field is required..
         /// </summary>
         internal static string MandatoryAttribute_ValidationError {

--- a/src/Qowaiv.Validation.DataAnnotations/QowaivValidationMessages.Designer.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/QowaivValidationMessages.Designer.cs
@@ -79,6 +79,33 @@ namespace Qowaiv.Validation.DataAnnotations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The {0} field should have at least {1} items..
+        /// </summary>
+        internal static string Collection_AtLeast_ValdationError {
+            get {
+                return ResourceManager.GetString("Collection_AtLeast_ValdationError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The {0} field should have at most {1} items..
+        /// </summary>
+        internal static string Collection_AtMost_ValidationError {
+            get {
+                return ResourceManager.GetString("Collection_AtMost_ValidationError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The number of items of the {0} field should be between {1} and {2}..
+        /// </summary>
+        internal static string Collection_InRange_ValidationError {
+            get {
+                return ResourceManager.GetString("Collection_InRange_ValidationError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to All values of the {0} field should be distinct..
         /// </summary>
         internal static string DistinctValuesAttribute_ValidationError {
@@ -138,6 +165,42 @@ namespace Qowaiv.Validation.DataAnnotations {
         internal static string MultipleOfAttribute_ValidationError {
             get {
                 return ResourceManager.GetString("MultipleOfAttribute_ValidationError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The size of the {0} field should be at least {1: F}..
+        /// </summary>
+        internal static string Size_AtLeast_ValdationError {
+            get {
+                return ResourceManager.GetString("Size_AtLeast_ValdationError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The size of the {0} field should be at most {1: F}..
+        /// </summary>
+        internal static string Size_AtMost_ValidationError {
+            get {
+                return ResourceManager.GetString("Size_AtMost_ValidationError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The size of the {0} field should be between {1: F} and {2: F}..
+        /// </summary>
+        internal static string Size_InRange_ValidationError {
+            get {
+                return ResourceManager.GetString("Size_InRange_ValidationError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} does not support properties of the type {1}..
+        /// </summary>
+        internal static string UnsupportedProperyType_For {
+            get {
+                return ResourceManager.GetString("UnsupportedProperyType_For", resourceCulture);
             }
         }
     }

--- a/src/Qowaiv.Validation.DataAnnotations/QowaivValidationMessages.nl.resx
+++ b/src/Qowaiv.Validation.DataAnnotations/QowaivValidationMessages.nl.resx
@@ -19,7 +19,7 @@
     <value>De waarde van het {0} veld is geen eindig getal.</value>
   </data>
   <data name="Length_AtLeast_ValdationError" xml:space="preserve">
-    <value>De lengte van het veld  {0} moet minstens {1} zijn.</value>
+    <value>De lengte van het veld {0} moet minstens {1} zijn.</value>
   </data>
   <data name="Length_AtMost_ValidationError" xml:space="preserve">
     <value>De lengte van het veld {0} mag niet meer dan {1} zijn.</value>

--- a/src/Qowaiv.Validation.DataAnnotations/QowaivValidationMessages.nl.resx
+++ b/src/Qowaiv.Validation.DataAnnotations/QowaivValidationMessages.nl.resx
@@ -18,6 +18,15 @@
   <data name="IsFiniteAttribute_ValidationError" xml:space="preserve">
     <value>De waarde van het {0} veld is geen eindig getal.</value>
   </data>
+  <data name="Length_AtLeast_ValdationError" xml:space="preserve">
+    <value>De lengte van het veld  {0} moet minstens {1} zijn.</value>
+  </data>
+  <data name="Length_AtMost_ValidationError" xml:space="preserve">
+    <value>De lengte van het veld {0} mag niet meer dan {1} zijn.</value>
+  </data>
+  <data name="Length_InRange_ValidationError" xml:space="preserve">
+    <value>De lengte van het veld {1} moet tussen de {1} en {2} zijn.</value>
+  </data>
   <data name="MandatoryAttribute_ValidationError" xml:space="preserve">
     <value>Het veld {0} is verplicht.</value>
   </data>

--- a/src/Qowaiv.Validation.DataAnnotations/QowaivValidationMessages.nl.resx
+++ b/src/Qowaiv.Validation.DataAnnotations/QowaivValidationMessages.nl.resx
@@ -12,6 +12,15 @@
   <data name="AllowedValuesAttribute_ValidationError" xml:space="preserve">
     <value>De waarde van het veld {0} is niet toegestaan.</value>
   </data>
+  <data name="Collection_AtLeast_ValdationError" xml:space="preserve">
+    <value>Veld {0} moet tenminste {1} items bevatten.</value>
+  </data>
+  <data name="Collection_AtMost_ValidationError" xml:space="preserve">
+    <value>Veld {0} mag niet meer dan {1} items bevatten.</value>
+  </data>
+  <data name="Collection_InRange_ValidationError" xml:space="preserve">
+    <value>Het aantal items van veld {0} moet tussen {1} en {2} zitten.</value>
+  </data>
   <data name="DistinctValuesAttribute_ValidationError" xml:space="preserve">
     <value>Alle waarden van het veld {0} zouden verschillend moeten zijn.</value>
   </data>
@@ -32,5 +41,14 @@
   </data>
   <data name="MultipleOfAttribute_ValidationError" xml:space="preserve">
     <value>De waarde van veld {0} is geen veelvoud van {1}.</value>
+  </data>
+  <data name="Size_AtLeast_ValdationError" xml:space="preserve">
+    <value>De grootte van het veld {0} moet minstens {1: F} zijn.</value>
+  </data>
+  <data name="Size_AtMost_ValidationError" xml:space="preserve">
+    <value>De grootte van het veld {0} mag niet meer dan {1: F} zijn.</value>
+  </data>
+  <data name="Size_InRange_ValidationError" xml:space="preserve">
+    <value>De grootte van het veld {1} moet tussen de {1: F} en {2: F} zijn.</value>
   </data>
 </root>

--- a/src/Qowaiv.Validation.DataAnnotations/QowaivValidationMessages.nl.resx
+++ b/src/Qowaiv.Validation.DataAnnotations/QowaivValidationMessages.nl.resx
@@ -12,7 +12,7 @@
   <data name="AllowedValuesAttribute_ValidationError" xml:space="preserve">
     <value>De waarde van het veld {0} is niet toegestaan.</value>
   </data>
-  <data name="Collection_AtLeast_ValdationError" xml:space="preserve">
+  <data name="Collection_AtLeast_ValidationError" xml:space="preserve">
     <value>Veld {0} moet tenminste {1} items bevatten.</value>
   </data>
   <data name="Collection_AtMost_ValidationError" xml:space="preserve">
@@ -27,14 +27,14 @@
   <data name="IsFiniteAttribute_ValidationError" xml:space="preserve">
     <value>De waarde van het {0} veld is geen eindig getal.</value>
   </data>
-  <data name="Length_AtLeast_ValdationError" xml:space="preserve">
+  <data name="Length_AtLeast_ValidationError" xml:space="preserve">
     <value>De lengte van het veld {0} moet minstens {1} zijn.</value>
   </data>
   <data name="Length_AtMost_ValidationError" xml:space="preserve">
     <value>De lengte van het veld {0} mag niet meer dan {1} zijn.</value>
   </data>
   <data name="Length_InRange_ValidationError" xml:space="preserve">
-    <value>De lengte van het veld {1} moet tussen de {1} en {2} zijn.</value>
+    <value>De lengte van het veld {0} moet tussen de {1} en {2} zijn.</value>
   </data>
   <data name="MandatoryAttribute_ValidationError" xml:space="preserve">
     <value>Het veld {0} is verplicht.</value>
@@ -42,13 +42,13 @@
   <data name="MultipleOfAttribute_ValidationError" xml:space="preserve">
     <value>De waarde van veld {0} is geen veelvoud van {1}.</value>
   </data>
-  <data name="Size_AtLeast_ValdationError" xml:space="preserve">
+  <data name="Size_AtLeast_ValidationError" xml:space="preserve">
     <value>De grootte van het veld {0} moet minstens {1: F} zijn.</value>
   </data>
   <data name="Size_AtMost_ValidationError" xml:space="preserve">
     <value>De grootte van het veld {0} mag niet meer dan {1: F} zijn.</value>
   </data>
   <data name="Size_InRange_ValidationError" xml:space="preserve">
-    <value>De grootte van het veld {1} moet tussen de {1: F} en {2: F} zijn.</value>
+    <value>De grootte van het veld {0} moet tussen de {1: F} en {2: F} zijn.</value>
   </data>
 </root>

--- a/src/Qowaiv.Validation.DataAnnotations/QowaivValidationMessages.resx
+++ b/src/Qowaiv.Validation.DataAnnotations/QowaivValidationMessages.resx
@@ -15,7 +15,7 @@
   <data name="ArgumentException_TypeIsNotEqualityComparer" xml:space="preserve">
     <value>The type {0} does not implement IEqualityComparer or IEqualityComarer&lt;object&gt;.</value>
   </data>
-  <data name="Collection_AtLeast_ValdationError" xml:space="preserve">
+  <data name="Collection_AtLeast_ValidationError" xml:space="preserve">
     <value>The {0} field should have at least {1} items.</value>
   </data>
   <data name="Collection_AtMost_ValidationError" xml:space="preserve">
@@ -30,7 +30,7 @@
   <data name="IsFiniteAttribute_ValidationError" xml:space="preserve">
     <value>The value of the {0} field is not a finite number.</value>
   </data>
-  <data name="Length_AtLeast_ValdationError" xml:space="preserve">
+  <data name="Length_AtLeast_ValidationError" xml:space="preserve">
     <value>The length of the {0} field should be at least {1}.</value>
   </data>
   <data name="Length_AtMost_ValidationError" xml:space="preserve">
@@ -45,7 +45,7 @@
   <data name="MultipleOfAttribute_ValidationError" xml:space="preserve">
     <value>The value of the {0} field is not a multiple of {1}.</value>
   </data>
-  <data name="Size_AtLeast_ValdationError" xml:space="preserve">
+  <data name="Size_AtLeast_ValidationError" xml:space="preserve">
     <value>The size of the {0} field should be at least {1: F}.</value>
   </data>
   <data name="Size_AtMost_ValidationError" xml:space="preserve">
@@ -54,7 +54,7 @@
   <data name="Size_InRange_ValidationError" xml:space="preserve">
     <value>The size of the {0} field should be between {1: F} and {2: F}.</value>
   </data>
-  <data name="UnsupportedProperyType_For" xml:space="preserve">
+  <data name="UnsupportedType_ForAttribute" xml:space="preserve">
     <value>{0} does not support properties of the type {1}.</value>
   </data>
 </root>

--- a/src/Qowaiv.Validation.DataAnnotations/QowaivValidationMessages.resx
+++ b/src/Qowaiv.Validation.DataAnnotations/QowaivValidationMessages.resx
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
- <resheader name="resmimetype">
-    <value>text/microsoft-resx</value>
+  <resheader name="resmimetype">
+  <value>text/microsoft-resx</value>
   </resheader>
   <resheader name="reader">
     <value>System.Resources.ResXResourceReader</value>
@@ -20,6 +20,15 @@
   </data>
   <data name="IsFiniteAttribute_ValidationError" xml:space="preserve">
     <value>The value of the {0} field is not a finite number.</value>
+  </data>
+  <data name="Length_AtLeast_ValdationError" xml:space="preserve">
+    <value>The length of the {0} field should be at least {1}.</value>
+  </data>
+  <data name="Length_AtMost_ValidationError" xml:space="preserve">
+    <value>The length of the {0} field should be at most {1}.</value>
+  </data>
+  <data name="Length_InRange_ValidationError" xml:space="preserve">
+    <value>The length of the {0} field should be between {1} and {2}.</value>
   </data>
   <data name="MandatoryAttribute_ValidationError" xml:space="preserve">
     <value>The {0} field is required.</value>

--- a/src/Qowaiv.Validation.DataAnnotations/QowaivValidationMessages.resx
+++ b/src/Qowaiv.Validation.DataAnnotations/QowaivValidationMessages.resx
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <resheader name="resmimetype">
-  <value>text/microsoft-resx</value>
+    <value>text/microsoft-resx</value>
   </resheader>
   <resheader name="reader">
     <value>System.Resources.ResXResourceReader</value>
@@ -14,6 +14,15 @@
   </data>
   <data name="ArgumentException_TypeIsNotEqualityComparer" xml:space="preserve">
     <value>The type {0} does not implement IEqualityComparer or IEqualityComarer&lt;object&gt;.</value>
+  </data>
+  <data name="Collection_AtLeast_ValdationError" xml:space="preserve">
+    <value>The {0} field should have at least {1} items.</value>
+  </data>
+  <data name="Collection_AtMost_ValidationError" xml:space="preserve">
+    <value>The {0} field should have at most {1} items.</value>
+  </data>
+  <data name="Collection_InRange_ValidationError" xml:space="preserve">
+    <value>The number of items of the {0} field should be between {1} and {2}.</value>
   </data>
   <data name="DistinctValuesAttribute_ValidationError" xml:space="preserve">
     <value>All values of the {0} field should be distinct.</value>
@@ -35,5 +44,17 @@
   </data>
   <data name="MultipleOfAttribute_ValidationError" xml:space="preserve">
     <value>The value of the {0} field is not a multiple of {1}.</value>
+  </data>
+  <data name="Size_AtLeast_ValdationError" xml:space="preserve">
+    <value>The size of the {0} field should be at least {1: F}.</value>
+  </data>
+  <data name="Size_AtMost_ValidationError" xml:space="preserve">
+    <value>The size of the {0} field should be at most {1: F}.</value>
+  </data>
+  <data name="Size_InRange_ValidationError" xml:space="preserve">
+    <value>The size of the {0} field should be between {1: F} and {2: F}.</value>
+  </data>
+  <data name="UnsupportedProperyType_For" xml:space="preserve">
+    <value>{0} does not support properties of the type {1}.</value>
   </data>
 </root>

--- a/src/Qowaiv.Validation.DataAnnotations/Reflection/ObjectWrapper.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Reflection/ObjectWrapper.cs
@@ -1,0 +1,37 @@
+﻿using System.Reflection;
+
+namespace Qowaiv.Validation.DataAnnotations.Reflection;
+
+internal static class ObjectWrapper
+{
+    /// <summary>Tries to resolve the value of the length property.</summary>
+    [Pure]
+    public static long? TryLength(this object obj) => obj switch
+    {
+        string str => str.Length,
+        Array array => array.Length,
+        _ => Try("Length", obj),
+    };
+
+    /// <summary>Tries to resolve the value of the count property.</summary>
+    [Pure]
+    public static long? TryCount(this object obj) => obj switch
+    {
+        ICollection collection => collection.Count,
+        _ => Try("Count", obj) ?? (obj as IEnumerable)?.Cast<object>().Count(),
+    };
+
+    [Pure]
+    private static long? Try(string name, object value)
+        => value.GetType().GetRuntimeProperty(name) is { CanRead: true } prop
+            ? GetValue(value, prop)
+            : null;
+
+    [Pure]
+    private static long? GetValue(object value, PropertyInfo property) => property.PropertyType switch
+    {
+        var type when type == typeof(int) => (int?)property.GetValue(value),
+        var type when type == typeof(long) => (long?)property.GetValue(value),
+        _ => null,
+    };
+}

--- a/src/Qowaiv.Validation.DataAnnotations/UnsupportedType.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/UnsupportedType.cs
@@ -19,7 +19,7 @@ public class UnsupportedType : NotSupportedException
     [Pure]
     public static UnsupportedType ForAttribute<TAttribute>(Type type) where TAttribute : ValidationAttribute
         => new(string.Format(
-            QowaivValidationMessages.UnsupportedProperyType_For,
+            QowaivValidationMessages.UnsupportedType_ForAttribute,
             typeof(TAttribute).ToCSharpString(),
             type.ToCSharpString()));
 }

--- a/src/Qowaiv.Validation.DataAnnotations/UnsupportedType.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/UnsupportedType.cs
@@ -1,0 +1,25 @@
+﻿namespace Qowaiv.Validation.DataAnnotations;
+
+/// <summary>The exception that is thrown is a type is not supported.</summary>
+public class UnsupportedType : NotSupportedException
+{
+    /// <summary>Initializes a new instance of the <see cref="UnsupportedType"/> class.</summary>
+    [ExcludeFromCodeCoverage/* Justification = Required for extensibility. */]
+    public UnsupportedType() { }
+
+    /// <summary>Initializes a new instance of the <see cref="UnsupportedType"/> class.</summary>
+    public UnsupportedType(string? message) : base(message) { }
+
+    /// <summary>Initializes a new instance of the <see cref="UnsupportedType"/> class.</summary>
+    [ExcludeFromCodeCoverage/* Justification = Required for extensibility. */]
+    public UnsupportedType(string? message, Exception? innerException)
+        : base(message, innerException) { }
+
+    /// <summary>Type is not supported by the <see cref="ValidationAttribute"/>.</summary>
+    [Pure]
+    public static UnsupportedType ForAttribute<TAttribute>(Type type) where TAttribute : ValidationAttribute
+        => new(string.Format(
+            QowaivValidationMessages.UnsupportedProperyType_For,
+            typeof(TAttribute).ToCSharpString(),
+            type.ToCSharpString()));
+}


### PR DESCRIPTION
The `System.ComponentModel.DataAnnotations` namespace contains multiple attributes to check for collection sizes and (string)lengths. Naming is - however - not intuitive, and messages do not clearly distinct between lengths and the number of elements.

For validation lengths:

* `[Length.AtLeast(minimum)]`
* `[Length.AtMost(maximum)]`
* `[Length.InRange(minimum, maximum)]`

For collections:
* `[Collection.AtLeast(minimum)]`
* `[Collection.AtMost(maximum)]`
* `[Collection.InRange(minimum, maximum)]`

For streams, byte arrays, and binary data:
* `[Size.AtLeast(minimum)]`
* `[Size.AtMost(maximum)]`
* `[Size.InRange(minimum, maximum)]`