### PR TITLE
Support requiredness via the required modifier

### DIFF
--- a/specs/Qowaiv.Validation.Specs/DataAnnotations/Required_modifier.cs
+++ b/specs/Qowaiv.Validation.Specs/DataAnnotations/Required_modifier.cs
@@ -28,7 +28,7 @@ public class Required_modifier
     {
         var model = new DecoratedModel { NotNullable = string.Empty };
 
-        var validator = new AnnotatedModelValidator<DecorateddModel>();
+        var validator = new AnnotatedModelValidator<DecoratedModel>();
 
         validator.Validate(model)
             .Should().BeValid()

--- a/specs/Qowaiv.Validation.Specs/DataAnnotations/Required_modifier.cs
+++ b/specs/Qowaiv.Validation.Specs/DataAnnotations/Required_modifier.cs
@@ -1,0 +1,87 @@
+using Qowaiv.Validation.DataAnnotations;
+using System.ComponentModel.DataAnnotations;
+
+namespace Specs.DataAnnotations;
+
+public class Required_modifier
+{
+    [TestCase(null)]
+    [TestCase("")]
+    public void makes_non_nullable_references_types_required(string? value)
+    {
+        var model = new RequiredModel
+        {
+            Nullable = "Some text",
+            NotNullable = value!,
+            Svo = EmailAddress.Parse("info@qowaiv.org"),
+        };
+
+        var validator = new AnnotatedModelValidator<RequiredModel>();
+
+        validator.Validate(model)
+            .Should().BeInvalid()
+            .WithMessage(ValidationMessage.Error("The NotNullable field is required.", "NotNullable"));
+    }
+
+    [Test]
+    public void has_lower_priority_than_attributes()
+    {
+        var model = new DecorateddModel { NotNullable = string.Empty };
+
+        var validator = new AnnotatedModelValidator<DecorateddModel>();
+
+        validator.Validate(model)
+            .Should().BeValid()
+            .WithMessages();
+    }
+
+    [TestCase(null)]
+    [TestCase("")]
+    public void does_not_alter_nullable_references_types(string? value)
+    {
+        var model = new RequiredModel
+        {
+            Nullable = value,
+            NotNullable ="Some value",
+            Svo = EmailAddress.Parse("info@qowaiv.org"),
+        };
+
+        var validator = new AnnotatedModelValidator<RequiredModel>();
+
+        validator.Validate(model)
+            .Should().BeValid()
+            .WithMessages();
+    }
+
+    [Test]
+    public void does_not_alter_reference_types()
+    {
+        var model = new RequiredModel
+        {
+            Nullable = null,
+            NotNullable = "Some value",
+            Svo = EmailAddress.Empty,
+        };
+
+        var validator = new AnnotatedModelValidator<RequiredModel>();
+
+        validator.Validate(model)
+            .Should().BeValid()
+            .WithMessages();
+    }
+
+    internal class RequiredModel
+    {
+        public required string? Nullable { get; init; }
+
+        public required string NotNullable { get; init; }
+
+        public required EmailAddress Svo { get; init; }
+    }
+
+    internal class DecorateddModel
+    {
+        [Required(AllowEmptyStrings = true)]
+        public required string NotNullable { get; init; }
+    }
+}

--- a/specs/Qowaiv.Validation.Specs/DataAnnotations/Required_modifier.cs
+++ b/specs/Qowaiv.Validation.Specs/DataAnnotations/Required_modifier.cs
@@ -79,7 +79,7 @@ public class Required_modifier
         public required EmailAddress Svo { get; init; }
     }
 
-    internal class DecorateddModel
+    internal class DecoratedModel
     {
         [Required(AllowEmptyStrings = true)]
         public required string NotNullable { get; init; }

--- a/specs/Qowaiv.Validation.Specs/DataAnnotations/Required_modifier.cs
+++ b/specs/Qowaiv.Validation.Specs/DataAnnotations/Required_modifier.cs
@@ -26,7 +26,7 @@ public class Required_modifier
     [Test]
     public void has_lower_priority_than_attributes()
     {
-        var model = new DecorateddModel { NotNullable = string.Empty };
+        var model = new DecoratedModel { NotNullable = string.Empty };
 
         var validator = new AnnotatedModelValidator<DecorateddModel>();
 

--- a/specs/Qowaiv.Validation.Specs/Qowaiv.Validation.Specs.csproj
+++ b/specs/Qowaiv.Validation.Specs/Qowaiv.Validation.Specs.csproj
@@ -9,7 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup Label="XML files as embedded">
-    <None Remove="Xml/Files/*" />
     <EmbeddedResource Include="Xml/Files/*" />
   </ItemGroup>
 

--- a/src/Qowaiv.Validation.DataAnnotations/AnnotatedProperty.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/AnnotatedProperty.cs
@@ -12,11 +12,13 @@ public sealed class AnnotatedProperty
     {
         PropertyType = property.PropertyType;
         Name = property.Name;
-        RequiredAttribute = property.RequiredAttribute() ?? OptionalAttribute.Optional;
+        RequiredAttribute = property.RequiredAttribute()
+            ?? property.RequiredMemberAttribute()
+            ?? OptionalAttribute.Optional;
         ValidationAttributes = property.ValidationAttributes().Where(attr => attr is not System.ComponentModel.DataAnnotations.RequiredAttribute).ToArray();
         IsValidatableObject = property.PropertyType.IsValidatableObject();
         IsEnumerable = PropertyType.IsEnumerable();
-        getValue = (model) => property.GetValue(model);
+        getValue = property.GetValue;
     }
 
     /// <summary>Gets the type of the property.</summary>

--- a/src/Qowaiv.Validation.DataAnnotations/Qowaiv.Validation.DataAnnotations.csproj
+++ b/src/Qowaiv.Validation.DataAnnotations/Qowaiv.Validation.DataAnnotations.csproj
@@ -10,6 +10,7 @@
     <PackageReleaseNotes>
       <![CDATA[
 ToBeReleased:
+- Support requiredness via the required modifier.
 - Update to Qowaiv v7.2.1. #88
 v3.0.0
 - Introduction of AllowedAttribute<T> as alternative to AllowedValuesAttribute.

--- a/src/Qowaiv.Validation.DataAnnotations/README.md
+++ b/src/Qowaiv.Validation.DataAnnotations/README.md
@@ -25,7 +25,7 @@ var error = ValidationMessage.Error(message, args);
 
 ## Required modifier
 The [`required`](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/required) modifier is available since C# 11.
-When a model has a property with `required` modifier, it is considered beining
+When a model has a property with a `required` modifier, it is considered being
 decorated with a `[Required]` attribute when the property:
 1. is a reference type
 2. lacks a nullable (`?`) annotation
@@ -46,7 +46,7 @@ public class Model
 ```
 
 the first property is considered required by the `AnnotatedModelValidator`. The
-second one is considered optional. The third one is also considered reqruied,
+second one is considered optional. The third one is also considered required,
 but via the attribute it was decorated with, not because of the `required` modifier.
 
 ## Validation attributes

--- a/src/Qowaiv.Validation.DataAnnotations/README.md
+++ b/src/Qowaiv.Validation.DataAnnotations/README.md
@@ -23,6 +23,32 @@ var warn = ValidationMessage.Warning(message, args);
 var error = ValidationMessage.Error(message, args);
 ```
 
+## Required modifier
+The [`required`](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/required) modifier is available since C# 11.
+When a model has a property with `required` modifier, it is considered beining
+decorated with a `[Required]` attribute when the property:
+1. is a reference type
+2. lacks a nullable (`?`) annotation
+3. is not decorated with a `[Required]` attribute.
+
+So in this example:
+
+``` C#
+public class Model
+{
+    public required string RequiredByModifier { get; init; }
+
+    public required string? Optional { get; init; }
+
+    [Required(AllowEmptyStrings = true)]
+    public required string AllowStringEmpty {get; init; }
+}
+```
+
+the first property is considered required by the `AnnotatedModelValidator`. The
+second one is considered optional. The third one is also considered reqruied,
+but via the attribute it was decorated with, not because of the `required` modifier.
+
 ## Validation attributes
 Multiple `[System.ComponentModel.DataAnnotations.Validation]` attributes can be
 used to decorate models.

--- a/src/Qowaiv.Validation.DataAnnotations/README.md
+++ b/src/Qowaiv.Validation.DataAnnotations/README.md
@@ -30,7 +30,6 @@ decorated with a `[Required]` attribute via the `required` modifier when the
 property:
 1. is a reference type
 2. lacks a nullable (`?`) annotation
-3. is not actually decorated with a `[Required]` attribute.
 
 So in this example:
 
@@ -46,8 +45,8 @@ public class Model
 }
 ```
 
-The first property is considered required by the `AnnotatedModelValidator`. The
-second one is considered optional. The third one is also considered required,
+The first property is considered required by the `AnnotatedModelValidator`, and
+the second one is considered optional. The third one is also considered required,
 but via the attribute it was decorated with, not because of the `required` modifier.
 
 ## Validation attributes

--- a/src/Qowaiv.Validation.DataAnnotations/README.md
+++ b/src/Qowaiv.Validation.DataAnnotations/README.md
@@ -26,10 +26,11 @@ var error = ValidationMessage.Error(message, args);
 ## Required modifier
 The [`required`](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/required) modifier is available since C# 11.
 When a model has a property with a `required` modifier, it is considered being
-decorated with a `[Required]` attribute when the property:
+decorated with a `[Required]` attribute via the `required` modifier when the
+property:
 1. is a reference type
 2. lacks a nullable (`?`) annotation
-3. is not decorated with a `[Required]` attribute.
+3. is not actually decorated with a `[Required]` attribute.
 
 So in this example:
 
@@ -45,7 +46,7 @@ public class Model
 }
 ```
 
-the first property is considered required by the `AnnotatedModelValidator`. The
+The first property is considered required by the `AnnotatedModelValidator`. The
 second one is considered optional. The third one is also considered required,
 but via the attribute it was decorated with, not because of the `required` modifier.
 

--- a/src/Qowaiv.Validation.DataAnnotations/Reflection/DataAnnotationsReflector.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Reflection/DataAnnotationsReflector.cs
@@ -5,7 +5,7 @@ namespace Qowaiv.Validation.DataAnnotations.Reflection;
 internal static class DataAnnotationsReflector
 {
     private static readonly RequiredAttribute RequiredMember = new();
-    
+
     /// <summary>Returns true if type implements <see cref="IValidatableObject"/>,
     /// or if the type has been decorated with any <see cref="ValidationAttribute"/>'s,
     /// or any of its properties.
@@ -51,7 +51,6 @@ internal static class DataAnnotationsReflector
     /// Get the <see cref="RequiredMember"/> attribute instance for reference types
     /// that are not nullable and defined as required properties.
     /// </summary>
-
     [Pure]
     public static RequiredAttribute? RequiredMemberAttribute(this PropertyInfo property)
     {

--- a/src/Qowaiv.Validation.DataAnnotations/Reflection/DataAnnotationsReflector.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Reflection/DataAnnotationsReflector.cs
@@ -4,6 +4,8 @@ namespace Qowaiv.Validation.DataAnnotations.Reflection;
 
 internal static class DataAnnotationsReflector
 {
+    private static readonly RequiredAttribute RequiredMember = new();
+    
     /// <summary>Returns true if type implements <see cref="IValidatableObject"/>,
     /// or if the type has been decorated with any <see cref="ValidationAttribute"/>'s,
     /// or any of its properties.
@@ -32,8 +34,7 @@ internal static class DataAnnotationsReflector
         && type.GetEnumerableType() is { };
 
     [Pure]
-    private static Type? GetEnumerableType(this Type type)
-        => type
+    private static Type? GetEnumerableType(this Type type) => type
         .GetInterfaces()
         .Find(iface =>
             iface.IsGenericType &&
@@ -42,9 +43,27 @@ internal static class DataAnnotationsReflector
 
     /// <summary>Gets the decorated <see cref="System.ComponentModel.DataAnnotations.RequiredAttribute"/> for the property.</summary>
     [Pure]
-    public static RequiredAttribute? RequiredAttribute(this PropertyInfo property)
-        => property.GetCustomAttributes<RequiredAttribute>(inherit: true)
-        .FirstOrDefault(attr => attr is not OptionalAttribute);
+    public static RequiredAttribute? RequiredAttribute(this PropertyInfo property) => property
+        .GetCustomAttributes<RequiredAttribute>(inherit: true)
+        .FirstOrDefault();
+
+    /// <summary>
+    /// Get the <see cref="RequiredMember"/> attribute instance for reference types
+    /// that are not nullable and defined as required properties.
+    /// </summary>
+
+    [Pure]
+    public static RequiredAttribute? RequiredMemberAttribute(this PropertyInfo property)
+    {
+        if (property.PropertyType.IsValueType) return null;
+
+        var attributes = property.GetCustomAttributes(inherit: true).Select(a => a.GetType());
+
+        return attributes.Any(a => a.FullName == "System.Runtime.CompilerServices.RequiredMemberAttribute")
+            && !attributes.Any(a => a.FullName == "System.Runtime.CompilerServices.NullableAttribute")
+            ? RequiredMember
+            : null;
+    }
 
     /// <summary>Gets the decorated <see cref="ValidationAttribute"/>'s for the property.</summary>
     [Pure]


### PR DESCRIPTION
The `required` modifier should be considered an alternative way of decorating a model.