### PR TITLE
ValidationMessage.None is null for DataAnnotations

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -25,7 +25,7 @@
     <PackageVersion Include="PolySharp" Version="1.15.0" />
     <PackageVersion Include="Qowaiv" Version="7.2.1" />
     <PackageVersion Include="Qowaiv.Analyzers.CSharp" Version="*" />
-    <PackageVersion Include="Qowaiv.Diagnostics.Contracts" Version="2.0.4" />
+    <PackageVersion Include="Qowaiv.Diagnostics.Contracts" Version="2.0.5" />
     <PackageVersion Include="Qowaiv.TestTools" Version="7.2.0" />
     <PackageVersion Include="SonarAnalyzer.CSharp" Version="*" />
     <PackageVersion Include="StyleCop.Analyzers" Version="*-*" />

--- a/specs/Qowaiv.Validation.Specs/DataAnnotations/Validation_message_specs.cs
+++ b/specs/Qowaiv.Validation.Specs/DataAnnotations/Validation_message_specs.cs
@@ -1,46 +1,12 @@
-#if NET8_0_OR_GREATER
-#else
 using Qowaiv.Validation.DataAnnotations;
 using ValidationSeverity = Qowaiv.Validation.Abstractions.ValidationSeverity;
 
 namespace Data_annotations.Validation_message_specs;
 
-public class Serializes
+public class None
 {
-    [Test, Obsolete("Binary serialization is considered harmful.")]
-    public void Info_message()
-    {
-        var message = ValidationMessage.Info("Can be serialized", "ErrorMessage", "MemberNames");
-        SerializeDeserialize.Binary(message).Should().BeEquivalentTo(new
-        {
-            Severity = ValidationSeverity.Info,
-            ErrorMessage = "Can be serialized",
-            MemberNames = new[] { "ErrorMessage", "MemberNames" },
-        });
-    }
-
-    [Test, Obsolete("Binary serialization is considered harmful.")]
-    public void Warning_message()
-    {
-        var message = ValidationMessage.Warn("Can be serialized", "ErrorMessage", "MemberNames");
-        SerializeDeserialize.Binary(message).Should().BeEquivalentTo(new
-        {
-            Severity = ValidationSeverity.Warning,
-            ErrorMessage = "Can be serialized",
-            MemberNames = new[] { "ErrorMessage", "MemberNames" },
-        });
-    }
-
-    [Test, Obsolete("Binary serialization is considered harmful.")]
-    public void Error_message()
-    {
-        var message = ValidationMessage.Error("Can be serialized", "ErrorMessage", "MemberNames");
-        SerializeDeserialize.Binary(message).Should().BeEquivalentTo(new
-        {
-            Severity = ValidationSeverity.Error,
-            ErrorMessage = "Can be serialized",
-            MemberNames = new[] { "ErrorMessage", "MemberNames" },
-        });
-    }
+    [Test]
+    public void returns_null()
+        => ValidationMessage.None.Should().BeNull();
+   
 }
-#endif

--- a/src/Qowaiv.Validation.DataAnnotations/NestedValidationContext.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/NestedValidationContext.cs
@@ -72,13 +72,15 @@ internal sealed class NestedValidationContext
     [Impure]
     public bool AddMessage(ValidationResult validationResult, bool violationOnType = false)
     {
-        var message = ValidationMessage.For(validationResult);
-        if (message.Severity > ValidationSeverity.None)
+        if (ValidationMessage.For(validationResult) is { Severity: not ValidationSeverity.None } message)
         {
             collection.Add(Update(message, violationOnType));
             return true;
         }
-        else return false;
+        else
+        {
+            return false;
+        }
 
         ValidationMessage Update(ValidationMessage message, bool violationOnType)
         {

--- a/src/Qowaiv.Validation.DataAnnotations/Qowaiv.Validation.DataAnnotations.csproj
+++ b/src/Qowaiv.Validation.DataAnnotations/Qowaiv.Validation.DataAnnotations.csproj
@@ -7,12 +7,17 @@
     <PackageValidationBaselineVersion>3.0.0</PackageValidationBaselineVersion>
     <Version>3.0.0</Version>
     <PackageId>Qowaiv.Validation.DataAnnotations</PackageId>
-    <PackageReleaseNotes>
+    <ToBeReleased>
       <![CDATA[
-ToBeReleased:
+v4.0.0
 - Support requiredness via the required modifier.
 - Introduction of [SkipValidation] to explictly skip validation of types and properties.
+- Qowaiv.Validation.DataAnnotations.ValidationMessage.None returns null. (BREAKING)
 - Update to Qowaiv v7.2.1. #88
+]]>
+    </ToBeReleased>
+    <PackageReleaseNotes>
+      <![CDATA[
 v3.0.0
 - Introduction of AllowedAttribute<T> as alternative to AllowedValuesAttribute.
 - Introduction of DefinedOnlyAttribute<T> as alternative to DefinedEnumValuesOnlyAttribute.

--- a/src/Qowaiv.Validation.DataAnnotations/README.md
+++ b/src/Qowaiv.Validation.DataAnnotations/README.md
@@ -17,7 +17,7 @@ Result<SomeModel> result = validator.Validate(model);
 This allows the creation of messages with different severities:
 
 ``` C#
-var none = ValidationMessage.None;
+var none = ValidationMessage.None; // returns null, but for telling the story ValidationMessage.None is preferred.
 var info = ValidationMessage.Info(message, args);
 var warn = ValidationMessage.Warning(message, args);
 var error = ValidationMessage.Error(message, args);
@@ -167,8 +167,8 @@ public class Model
 ```
 
 ### Unique values
-The `[Unique&lt;TValue&gt;]` attribute validates that all items of the collection are
-distinct. If needed, a custom `IEqualityComparer&lt;TValue&gt` comparer can be defined.
+The `[Unique<Value>]` attribute validates that all items of the collection are
+distinct. If needed, a custom `IEqualityComparer<Value>` comparer can be defined.
 
 ``` C#
 public class Model

--- a/src/Qowaiv.Validation.DataAnnotations/ValidationMessage.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/ValidationMessage.cs
@@ -8,8 +8,6 @@ namespace Qowaiv.Validation.DataAnnotations;
 public class ValidationMessage : ValidationResult, IValidationMessage
 {
     /// <summary>Initializes a new instance of the <see cref="ValidationMessage"/> class.</summary>
-    public ValidationMessage() : this(ValidationSeverity.None, null, null) => Do.Nothing();
-
     internal ValidationMessage(ValidationSeverity severity, string? message, string[]? memberNames)
         : base(message, memberNames ?? [])
         => Severity = severity;
@@ -23,8 +21,12 @@ public class ValidationMessage : ValidationResult, IValidationMessage
     /// <inheritdoc />
     public string? Message => ErrorMessage;
 
-    /// <summary>Creates a None message.</summary>
-    public static ValidationMessage None => new();
+    /// <summary>Represents a validation message with severity <see cref="ValidationSeverity.None"/>.</summary>
+    /// <remarks>
+    /// Other tooling can not work properly with <see cref="ValidationMessage"/>s
+    /// that try to represent <see cref="ValidationResult.Success"/>.
+    /// </remarks>
+    public static readonly ValidationMessage? None = null;
 
     /// <summary>Creates an error message.</summary>
     [Pure]
@@ -43,24 +45,21 @@ public class ValidationMessage : ValidationResult, IValidationMessage
     /// The validation result to convert.
     /// </param>
     [Pure]
-    public static ValidationMessage For(ValidationResult validationResult)
-        => validationResult switch
-        {
-            null => None,
-            ValidationMessage message => message,
-            _ => validationResult == Success
-                ? None
-                : Error(validationResult.ErrorMessage, validationResult.MemberNames.ToArray()),
-        };
+    public static ValidationMessage? For(ValidationResult validationResult) => validationResult switch
+    {
+        ValidationMessage message => message,
+        null => None,
+        var r when r == Success => None,
+        _ => Error(validationResult.ErrorMessage, validationResult.MemberNames.ToArray()),
+    };
 
     /// <summary>Creates a validation message.</summary>
     [Pure]
-    public static IValidationMessage For(ValidationSeverity severity, string message, params string[] memberNames)
-        => severity switch
-        {
-            ValidationSeverity.None => None,
-            ValidationSeverity.Info => Info(message, memberNames),
-            ValidationSeverity.Warning => Warn(message, memberNames),
-            _ => Error(message, memberNames),
-        };
+    public static IValidationMessage? For(ValidationSeverity severity, string message, params string[] memberNames) => severity switch
+    {
+        ValidationSeverity.None => None,
+        ValidationSeverity.Info => Info(message, memberNames),
+        ValidationSeverity.Warning => Warn(message, memberNames),
+        _ => Error(message, memberNames),
+    };
 }


### PR DESCRIPTION
It turns out that Microsoft's [`System.ComponentModel.DataAnnotations.Validator`](https://source.dot.net/#System.ComponentModel.Annotations/System/ComponentModel/DataAnnotations/Validator.cs) converts a `Qowaiv.Validation.DataAnnotations.ValidationMessage.None` into an an error. This obviously undesired behavior. Hence the (breaking) change of communicating `null` in that case.