### PR TITLE
Support primitives of the same type for SetOfAttribute<TValue>

### DIFF
--- a/specs/Qowaiv.Validation.Specs/DataAnnotations/Attributes/SetOf_values_specs.cs
+++ b/specs/Qowaiv.Validation.Specs/DataAnnotations/Attributes/SetOf_values_specs.cs
@@ -12,7 +12,7 @@ public class Supports
         .Should().BeEquivalentTo([17, 42]);
 
     [Test]
-    public void pimitive_params_that_can_be_converted()
+    public void primitive_params_that_can_be_converted()
     {
         using (TestCultures.en_US.Scoped())
         {

--- a/specs/Qowaiv.Validation.Specs/DataAnnotations/Attributes/SetOf_values_specs.cs
+++ b/specs/Qowaiv.Validation.Specs/DataAnnotations/Attributes/SetOf_values_specs.cs
@@ -7,7 +7,7 @@ namespace Data_Annotations.Attributes.SetOf_values_specs;
 public class Supports
 {
     [Test]
-    public void pimitive_params_of_same_type_as_TValue()
+    public void primitive_params_of_same_type_as_TValue()
         => new AllowedAttribute<int>(17, 42).Values
         .Should().BeEquivalentTo([17, 42]);
 

--- a/specs/Qowaiv.Validation.Specs/DataAnnotations/Attributes/SetOf_values_specs.cs
+++ b/specs/Qowaiv.Validation.Specs/DataAnnotations/Attributes/SetOf_values_specs.cs
@@ -1,0 +1,23 @@
+using Qowaiv.Financial;
+using Qowaiv.TestTools.Globalization;
+using Qowaiv.Validation.DataAnnotations;
+
+namespace Data_Annotations.Attributes.SetOf_values_specs;
+
+public class Supports
+{
+    [Test]
+    public void pimitive_params_of_same_type_as_TValue()
+        => new AllowedAttribute<int>(17, 42).Values
+        .Should().BeEquivalentTo([17, 42]);
+
+    [Test]
+    public void pimitive_params_that_can_be_converted()
+    {
+        using (TestCultures.en_US.Scoped())
+        {
+            new AllowedAttribute<Amount>(42.12, "17.30").Values
+                .Should().BeEquivalentTo([42.12.Amount(), 17.30.Amount()]);
+        }
+    }
+}

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/AllowedAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/AllowedAttribute.cs
@@ -7,10 +7,9 @@ public sealed class AllowedAttribute<TValue> : SetOfAttribute<TValue>
 {
     /// <summary>Initializes a new instance of the <see cref="AllowedAttribute{TValue}"/> class.</summary>
     /// <param name="values">
-    /// String representations of the allowed values.
+    /// Representations of the allowed values.
     /// </param>
-    public AllowedAttribute(params object[] values)
-        : base(values) => Do.Nothing();
+    public AllowedAttribute(params object[] values) : base(values) { }
 
     /// <summary>Return true the value of <see cref="SetOfAttribute{TValue}.IsValid(object)"/>
     /// equals one of the values of the <see cref="SetOfAttribute{TValue}" />.

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/ForbiddenAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/ForbiddenAttribute.cs
@@ -7,10 +7,9 @@ public sealed class ForbiddenAttribute<TValue> : SetOfAttribute<TValue>
 {
     /// <summary>Initializes a new instance of the <see cref="ForbiddenAttribute{TValue}"/> class.</summary>
     /// <param name="values">
-    /// String representations of the forbidden values.
+    /// Representations of the forbidden values.
     /// </param>
-    public ForbiddenAttribute(params object[] values)
-        : base(values) => Do.Nothing();
+    public ForbiddenAttribute(params object[] values) : base(values) { }
 
     /// <summary>Return false if the value of <see cref="SetOfValuesAttribute.IsValid(object)"/>
     /// equals one of the values of the <see cref="ForbiddenAttribute{TValue}"/>.

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/SetOfAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/SetOfAttribute.cs
@@ -10,13 +10,27 @@ public abstract class SetOfAttribute<TValue> : ValidationAttribute
 {
     /// <summary>Initializes a new instance of the <see cref="SetOfAttribute{TValue}"/> class.</summary>
     /// <param name="values">
-    /// String representations of the values.
+    /// Representations of the values.
     /// </param>
     protected SetOfAttribute(params object[] values)
         : base(() => QowaivValidationMessages.AllowedValuesAttribute_ValidationError)
     {
-        var converter = TypeDescriptor.GetConverter(typeof(TValue));
-        Values = new HashSet<TValue>(values.Select(converter.ConvertFrom).OfType<TValue>());
+        var all = new HashSet<TValue>();
+
+        TypeConverter converter = TypeDescriptor.GetConverter(typeof(TValue));
+
+        foreach (var value in values)
+        {
+            if (value is TValue typed)
+            {
+                all.Add(typed);
+            }
+            else if (converter.ConvertFrom(value) is TValue converted)
+            {
+                all.Add(converted);
+            }
+        }
+        Values = all;
     }
 
     /// <summary>The result to return when the value of <see cref="IsValid(object)"/>

--- a/src/Qowaiv.Validation.DataAnnotations/Qowaiv.Validation.DataAnnotations.csproj
+++ b/src/Qowaiv.Validation.DataAnnotations/Qowaiv.Validation.DataAnnotations.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="../../props/package.props" />
 
@@ -7,12 +7,17 @@
     <PackageValidationBaselineVersion>3.0.0</PackageValidationBaselineVersion>
     <Version>3.0.0</Version>
     <PackageId>Qowaiv.Validation.DataAnnotations</PackageId>
-    <PackageReleaseNotes>
+    <ToBeReleased>
       <![CDATA[
-ToBeReleased:
+      <![CDATA[
+v4.0.0
+- Support primitives of the same type on [ValueOf<TValue>] attributes.
 - Support requiredness via the required modifier.
 - Introduction of [SkipValidation] to explictly skip validation of types and properties.
-- Update to Qowaiv v7.2.1. #88
+]]>
+    </ToBeReleased>
+    <PackageReleaseNotes>
+      <![CDATA[
 v3.0.0
 - Introduction of AllowedAttribute<T> as alternative to AllowedValuesAttribute.
 - Introduction of DefinedOnlyAttribute<T> as alternative to DefinedEnumValuesOnlyAttribute.

--- a/src/Qowaiv.Validation.DataAnnotations/README.md
+++ b/src/Qowaiv.Validation.DataAnnotations/README.md
@@ -83,7 +83,7 @@ public class Model
 
 ### Allowed values
 The `[AllowedValues]` attribute allows to define a subset of allowed values. It
-supports type converters to get the allowed values based on a string value.
+supports type converters to get the allowed values based on a primitive value.
 
 ``` C#
 public class Model
@@ -95,7 +95,7 @@ public class Model
 
 ### Forbidden values
 The `[ForbiddenValues]` attribute allows to define a subset of forbidden values. It
-supports type converters to get the forbidden values based on a string value.
+supports type converters to get the forbidden values based on a primitive value.
 
 ``` C#
 public class Model


### PR DESCRIPTION
Using primitives in `[Allowed<TValue>]` and `[Forbidden<TValue>]` where the primitive is `TValue` should not crash but be supported:

``` C#
class Model
{
    [Allowed<int>(42)]
    public int Answer { get; init; }
}
```