### PR TITLE
Introduction of [Items<TValidator>] to define a validator on the items of a collection

### DIFF
--- a/specs/Qowaiv.Validation.Specs/DataAnnotations/Attributes/Items_specs.cs
+++ b/specs/Qowaiv.Validation.Specs/DataAnnotations/Attributes/Items_specs.cs
@@ -1,0 +1,21 @@
+using Qowaiv.Validation.DataAnnotations;
+
+namespace Data_annotations.Attributes.Items_specs;
+
+public class Validates
+{
+    [Test]
+    public void itmes_according_to_wrapped_attribute()
+    {
+        var model = new Data_Annotations.Model.With.ValidatableArrayItems 
+        {
+            Numbers = [0, 42, 13],
+            Emails = [EmailAddress.Parse("info@qowaiv.org"), EmailAddress.Unknown],
+        };
+        model.ValidateAnnotations()
+            .Should().BeInvalid()
+            .WithMessages(
+                ValidationMessage.Error("The value of the Number field is not allowed.", "Numbers[0]", "Numbers[2]"),
+                ValidationMessage.Error("Emails must be specified.", "Emails[1]"));
+    }
+}

--- a/specs/Qowaiv.Validation.Specs/DataAnnotations/Attributes/Items_specs.cs
+++ b/specs/Qowaiv.Validation.Specs/DataAnnotations/Attributes/Items_specs.cs
@@ -5,7 +5,7 @@ namespace Data_annotations.Attributes.Items_specs;
 public class Validates
 {
     [Test]
-    public void itmes_according_to_wrapped_attribute()
+    public void items_according_to_wrapped_attribute()
     {
         var model = new Data_Annotations.Model.With.ValidatableArrayItems 
         {

--- a/specs/Qowaiv.Validation.Specs/DataAnnotations/Attributes/Model.cs
+++ b/specs/Qowaiv.Validation.Specs/DataAnnotations/Attributes/Model.cs
@@ -1,0 +1,21 @@
+using Qowaiv.Validation.DataAnnotations;
+using System.ComponentModel.DataAnnotations;
+
+namespace Data_Annotations;
+
+internal static class Model
+{
+    public static class With
+    {
+        public sealed class ValidatableArrayItems
+        {
+            [Any]
+            [Display(Name = "Number")]
+            [Items<AllowedAttribute<int>>(42)]
+            public int[] Numbers { get; init; } = [];
+
+            [Items<MandatoryAttribute>(ErrorMessage = "Emails must be specified.")]
+            public EmailAddress[] Emails { get; init; } = [];
+        }
+    }
+}

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/ItemsAttributes.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/ItemsAttributes.cs
@@ -1,0 +1,111 @@
+namespace Qowaiv.Validation.DataAnnotations;
+
+/// <summary>Validates if all items of the collection are valid according to the wrapped validator.</summary>
+/// <typeparam name="TValidator">
+/// The validator to validate the items with.
+/// </typeparam>
+[AttributeUsage(AttributeTargets.Property|AttributeTargets.Field|AttributeTargets.Parameter, AllowMultiple = true, Inherited = false)]
+[CLSCompliant(false)]
+public sealed class ItemsAttribute<TValidator> : ValidationAttribute
+    where TValidator : ValidationAttribute
+{
+    /// <summary>Initializes a new instance of the <see cref="ItemsAttribute{TValidator}"/> class.</summary>
+    /// <param name="args">
+    /// The args to provide to the constructor of <typeparamref name="TValidator"/> .
+    /// </param>
+    public ItemsAttribute(params object[] args)
+    {
+        Validator = Create(args);
+    }
+
+    private readonly TValidator Validator;
+
+    /// <inheritdoc />
+    public override bool RequiresValidationContext => true;
+
+    /// <inheritdoc />
+    [Pure]
+    protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
+    {
+        var index = 0;
+
+        if (value is IEnumerable enumerable)
+        {
+            var violations = new List<int>();
+
+            foreach (var item in enumerable)
+            {
+                if (!Validator.IsValid(item))
+                {
+                    violations.Add(index);
+                }
+                index++;
+            }
+
+            if (violations.Count > 0)
+            {
+                return ValidationMessage.Error(FormatErrorMessage(validationContext.DisplayName), [.. violations.Select(i => $"{validationContext.MemberName}[{i}]")]);
+            }
+        }
+        return null;
+    }
+
+    /// <inheritdoc />
+    [Pure]
+    public override string FormatErrorMessage(string name)
+    {
+        if (Init)
+        {
+            if (ErrorMessageResourceName is { }) Validator.ErrorMessageResourceName = ErrorMessageResourceName;
+            if (ErrorMessageResourceType is { }) Validator.ErrorMessageResourceType = ErrorMessageResourceType;
+
+            // If the error message is updated, reset the resource based setting.
+            if (ErrorMessage is { })
+            {
+                Validator.ErrorMessageResourceName = null;
+                Validator.ErrorMessageResourceType = null;
+                Validator.ErrorMessage = ErrorMessage;
+            }
+
+            Init = false;
+        }
+        return Validator.FormatErrorMessage(name);
+    }
+
+    private bool Init = true;
+
+    [Pure]
+    private static TValidator Create(object[] args)
+    {
+        try
+        {
+            if (args.Length == 0)
+            {
+                return Activator.CreateInstance<TValidator>();
+            }
+
+            // if there are multiple ctors with 
+            var ctor = typeof(TValidator).GetConstructors().Single(c => c.GetParameters().Length > 0);
+            var input = new List<object>();
+            var i = 0;
+
+            foreach (var parameter in ctor.GetParameters())
+            {
+                // This should be the last argument: what is left is put in.
+                if (parameter.ParameterType.IsArray)
+                {
+                    input.Add(args.Skip(i).ToArray());
+                }
+                else
+                {
+                    input.Add(args[i++]);
+                }
+            }
+            return (TValidator)ctor.Invoke([.. input]);
+        }
+        catch (Exception x)
+        {
+            throw new ArgumentException("The args could not be used ", nameof(args), x);
+        }
+    }
+}

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/ItemsAttributes.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/ItemsAttributes.cs
@@ -6,17 +6,20 @@ namespace Qowaiv.Validation.DataAnnotations;
 /// </typeparam>
 [AttributeUsage(AttributeTargets.Property|AttributeTargets.Field|AttributeTargets.Parameter, AllowMultiple = true, Inherited = false)]
 [CLSCompliant(false)]
-public sealed class ItemsAttribute<TValidator> : ValidationAttribute
+public class ItemsAttribute<TValidator> : ValidationAttribute
     where TValidator : ValidationAttribute
 {
     /// <summary>Initializes a new instance of the <see cref="ItemsAttribute{TValidator}"/> class.</summary>
     /// <param name="args">
     /// The args to provide to the constructor of <typeparamref name="TValidator"/> .
     /// </param>
-    public ItemsAttribute(params object[] args)
-    {
-        Validator = Create(args);
-    }
+    public ItemsAttribute(params object[] args) : this(Create(args)) { }
+
+    /// <summary>Initializes a new instance of the <see cref="ItemsAttribute{TValidator}"/> class.</summary>
+    /// <param name="validator">
+    /// The validator to use.
+    /// </param>
+    protected ItemsAttribute(TValidator validator) => Validator = Guard.NotNull(validator);
 
     private readonly TValidator Validator;
 

--- a/src/Qowaiv.Validation.DataAnnotations/Qowaiv.Validation.DataAnnotations.csproj
+++ b/src/Qowaiv.Validation.DataAnnotations/Qowaiv.Validation.DataAnnotations.csproj
@@ -12,6 +12,7 @@
 v4.0.0
 - Support primitives of the same type on [ValueOf<TValue>] attributes.
 - Support requiredness via the required modifier.
+- Introduction of [Items<TValidator>] to define a validator on the items of a collection.
 - Introduction of [SkipValidation] to explictly skip validation of types and properties.
 - Qowaiv.Validation.DataAnnotations.ValidationMessage.None returns null. (BREAKING)
 - Update to Qowaiv v7.2.1. #88

--- a/src/Qowaiv.Validation.DataAnnotations/README.md
+++ b/src/Qowaiv.Validation.DataAnnotations/README.md
@@ -119,14 +119,14 @@ public class Model
 }
 ```
 
-### Items valdation
+### Items validation
 The `[Items<TValidator>]` attribute to define a validation attribute to apply
 on all items of a collection. This is useful in multiple cases:
 
 ``` C#
 public class Model
 {
-    [Items<Mandatory>] // ensures not of the items is null or empty
+    [Items<Mandatory>] // ensures none of the items is null or empty
     public string[] Names { get; init; } = [];
 
     [Items<Allowed<int>(42, 2017)] // ensures that all items have either the value 42 or 2017.

--- a/src/Qowaiv.Validation.DataAnnotations/README.md
+++ b/src/Qowaiv.Validation.DataAnnotations/README.md
@@ -119,6 +119,24 @@ public class Model
 }
 ```
 
+### Items valdation
+The `[Items<TValidator>]` attribute to define a validation attribute to apply
+on all items of a collection. This is useful in multiple cases:
+
+``` C#
+public class Model
+{
+    [Items<Mandatory>] // ensures not of the items is null or empty
+    public string[] Names { get; init; } = [];
+
+    [Items<Allowed<int>(42, 2017)] // ensures that all items have either the value 42 or 2017.
+    public int[] Numbers { get; init; } = [];
+}
+```
+
+By defining either `ErrorMessage` or both `ErrorMessageResourceName` and `ErrorMessageResourceType`,
+those values are set to the `TValidator` allowing full control of the error message generation.
+
 ### Is finite
 The `[IsFinite]` attribute validates that the floating point value of the field
 represents a finite (e.a. not NaN, or infinity).


### PR DESCRIPTION
The `[Items<TValidator>]` attribute to define a validation attribute to apply on all items of a collection. This is useful in multiple cases:

``` C#
public class Model
{
    [Items<Mandatory>] // ensures not of the items is null or empty
    public string[] Names { get; init; } = [];

    [Items<Allowed<int>(42, 2017)] // ensures that all items have either the value 42 or 2017.
    public int[] Numbers { get; init; } = [];
}
```

By defining either `ErrorMessage` or both `ErrorMessageResourceName` and `ErrorMessageResourceType`, those values are set to the `TValidator` allowing full control of the error message generation.