### PR TITLE
Annotate validation attributes

### DIFF
--- a/specs/Qowaiv.Validation.Specs/DataAnnotations/Attributes/Is_finite_specs.cs
+++ b/specs/Qowaiv.Validation.Specs/DataAnnotations/Attributes/Is_finite_specs.cs
@@ -37,7 +37,7 @@ public class Is_invalid_for
     [TestCase(128L)]
     [TestCase(1024UL)]
     public void non_floating_points(object value)
-       => value.Invoking(_ => new IsFiniteAttribute().IsValid(value))
+        => value.Invoking(_ => new IsFiniteAttribute().IsValid(value))
         .Should().Throw<UnsupportedType>();
 }
 public class With_message

--- a/specs/Qowaiv.Validation.Specs/DataAnnotations/Attributes/Is_finite_specs.cs
+++ b/specs/Qowaiv.Validation.Specs/DataAnnotations/Attributes/Is_finite_specs.cs
@@ -37,7 +37,8 @@ public class Is_invalid_for
     [TestCase(128L)]
     [TestCase(1024UL)]
     public void non_floating_points(object value)
-       => new IsFiniteAttribute().IsValid(value).Should().BeFalse();
+       => value.Invoking(_ => new IsFiniteAttribute().IsValid(value))
+        .Should().Throw<UnsupportedType>();
 }
 public class With_message
 {

--- a/specs/Qowaiv.Validation.Specs/DataAnnotations/Attributes/Multiple_of_specs.cs
+++ b/specs/Qowaiv.Validation.Specs/DataAnnotations/Attributes/Multiple_of_specs.cs
@@ -132,7 +132,7 @@ public class Not_valid_for
 
     [TestCaseSource(nameof(NotSupportedTypes))]
     public void not_supported_types(object model)
-        =>  new MultipleOfAttribute(10).IsValid(model).Should().BeFalse();
+        => new MultipleOfAttribute(10).IsValid(model).Should().BeFalse();
 
     static IEnumerable<object?> NotSupportedTypes()
     {

--- a/specs/Qowaiv.Validation.Specs/DataAnnotations/Attributes/Multiple_of_specs.cs
+++ b/specs/Qowaiv.Validation.Specs/DataAnnotations/Attributes/Multiple_of_specs.cs
@@ -132,15 +132,13 @@ public class Not_valid_for
 
     [TestCaseSource(nameof(NotSupportedTypes))]
     public void not_supported_types(object model)
-        => new MultipleOfAttribute(10).IsValid(model).Should().BeFalse();
+        =>  new MultipleOfAttribute(10).IsValid(model).Should().BeFalse();
 
     static IEnumerable<object?> NotSupportedTypes()
     {
         yield return true;
         yield return "Hello, World!";
         yield return 'C';
-        yield return new[] { 42 };
-        yield return new object();
         yield return new DateTime(2017, 06, 11, 06, 15, 00, DateTimeKind.Local);
         yield return DBNull.Value;
     }

--- a/specs/Qowaiv.Validation.Specs/DataAnnotations/ValidationAttribute_specs.cs
+++ b/specs/Qowaiv.Validation.Specs/DataAnnotations/ValidationAttribute_specs.cs
@@ -10,6 +10,6 @@ public class All
         .Where(t => !t.IsAbstract && t.IsAssignableTo(typeof(ValidationAttribute)));
 
     [TestCaseSource(nameof(Attributes))]
-    public void are_decorated_with_ValidatesAttribute(Type attrribute)
-        => attrribute.Should().BeDecoratedWith<ValidatesAttribute>();
+    public void are_decorated_with_ValidatesAttribute(Type attribute)
+        => attribute.Should().BeDecoratedWith<ValidatesAttribute>();
 }

--- a/specs/Qowaiv.Validation.Specs/DataAnnotations/ValidationAttribute_specs.cs
+++ b/specs/Qowaiv.Validation.Specs/DataAnnotations/ValidationAttribute_specs.cs
@@ -1,0 +1,15 @@
+using Qowaiv.Validation.DataAnnotations;
+using System.ComponentModel.DataAnnotations;
+
+namespace Data_Annotations.ValidationAttribute_specs;
+
+public class All
+{
+    public static IEnumerable<Type> Attributes => typeof(ValidationMessage).Assembly
+        .GetExportedTypes()
+        .Where(t => !t.IsAbstract && t.IsAssignableTo(typeof(ValidationAttribute)));
+
+    [TestCaseSource(nameof(Attributes))]
+    public void are_decorated_with_ValidatesAttribute(Type attrribute)
+        => attrribute.Should().BeDecoratedWith<ValidatesAttribute>();
+}

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/AllowedAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/AllowedAttribute.cs
@@ -3,6 +3,7 @@ namespace Qowaiv.Validation.DataAnnotations;
 /// <summary>Validates if the decorated item has a value that is specified in the allowed values.</summary>
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
 [CLSCompliant(false)]
+[Validates(GenericArgument = true)]
 public sealed class AllowedAttribute<TValue> : SetOfAttribute<TValue>
 {
     /// <summary>Initializes a new instance of the <see cref="AllowedAttribute{TValue}"/> class.</summary>

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/AnyAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/AnyAttribute.cs
@@ -2,6 +2,7 @@ namespace Qowaiv.Validation.DataAnnotations;
 
 /// <summary>Specifies that a field should at least have one item in its collection.</summary>
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
+[Validates(typeof(IEnumerable))]
 public class AnyAttribute : RequiredAttribute
 {
     /// <summary>Initializes a new instance of the <see cref="AnyAttribute"/> class.</summary>

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/Collection.AtLeastAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/Collection.AtLeastAttribute.cs
@@ -5,6 +5,7 @@ public static partial class Collection
 {
     /// <summary>Specifies the minimum the length of property, field or parameter.</summary>
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
+    [Validates(typeof(object))]
     public sealed class AtLeastAttribute(long minimum)
         : ValidationAttribute(() => QowaivValidationMessages.Collection_AtLeast_ValidationError)
     {

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/Collection.AtMostAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/Collection.AtMostAttribute.cs
@@ -5,6 +5,7 @@ public static partial class Collection
 {
     /// <summary>Specifies the maximum the length of property, field or parameter.</summary>
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
+    [Validates(typeof(object))]
     public sealed class AtMostAttribute(long maximum)
         : ValidationAttribute(() => QowaivValidationMessages.Collection_AtMost_ValidationError)
     {

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/Collection.InRangeAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/Collection.InRangeAttribute.cs
@@ -5,6 +5,7 @@ public static partial class Collection
 {
     /// <summary>Specifies the allowed range of the length of property, field or parameter.</summary>
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
+    [Validates(typeof(object))]
     public sealed class InRangeAttribute(long minimum, long maximum)
         : ValidationAttribute(() => QowaivValidationMessages.Collection_InRange_ValidationError)
     {

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/DefinedOnlyAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/DefinedOnlyAttribute.cs
@@ -7,6 +7,7 @@ namespace Qowaiv.Validation.DataAnnotations;
 /// The type of the enum.
 /// </typeparam>
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
+[Validates(GenericArgument = true)]
 public class DefinedOnlyAttribute<TEnum> : ValidationAttribute
     where TEnum : struct, Enum
 {

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/ForbiddenAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/ForbiddenAttribute.cs
@@ -3,6 +3,7 @@ namespace Qowaiv.Validation.DataAnnotations;
 /// <summary>Validates if the decorated item has a value that is specified in the forbidden values.</summary>
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
 [CLSCompliant(false)]
+[Validates(GenericArgument = true)]
 public sealed class ForbiddenAttribute<TValue> : SetOfAttribute<TValue>
 {
     /// <summary>Initializes a new instance of the <see cref="ForbiddenAttribute{TValue}"/> class.</summary>

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/IsFiniteAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/IsFiniteAttribute.cs
@@ -2,6 +2,8 @@ namespace Qowaiv.Validation.DataAnnotations;
 
 /// <summary>Specifies that a field is a finite number.</summary>
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
+[Validates(typeof(float))]
+[Validates(typeof(double))]
 public sealed class IsFiniteAttribute : ValidationAttribute
 {
     /// <summary>Initializes a new instance of the <see cref="IsFiniteAttribute"/> class.</summary>
@@ -13,12 +15,11 @@ public sealed class IsFiniteAttribute : ValidationAttribute
 
     /// <inheritdoc />
     [Pure]
-    public override bool IsValid(object? value)
-        => value is null
-        || value switch
-        {
-            float flt => flt.IsFinite(),
-            double dbl => dbl.IsFinite(),
-            _ => false,
-        };
+    public override bool IsValid(object? value) => value switch
+    {
+        null => true,
+        float flt => flt.IsFinite(),
+        double dbl => dbl.IsFinite(),
+        _ => throw UnsupportedType.ForAttribute<IsFiniteAttribute>(value.GetType()),
+    };
 }

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/ItemsAttributes.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/ItemsAttributes.cs
@@ -6,6 +6,7 @@ namespace Qowaiv.Validation.DataAnnotations;
 /// </typeparam>
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = true, Inherited = false)]
 [CLSCompliant(false)]
+[Validates(typeof(IEnumerable))]
 public class ItemsAttribute<TValidator> : ValidationAttribute
     where TValidator : ValidationAttribute
 {

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/Length.AtLeastAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/Length.AtLeastAttribute.cs
@@ -5,6 +5,7 @@ public static partial class Length
 {
     /// <summary>Specifies the minimum the length of property, field or parameter.</summary>
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
+    [Validates(typeof(object))]
     public sealed class AtLeastAttribute(long minimum)
         : ValidationAttribute(() => QowaivValidationMessages.Length_AtLeast_ValidationError)
     {

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/Length.AtMostAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/Length.AtMostAttribute.cs
@@ -5,6 +5,7 @@ public static partial class Length
 {
     /// <summary>Specifies the maximum the length of property, field or parameter.</summary>
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
+    [Validates(typeof(object))]
     public sealed class AtMostAttribute(long maximum)
         : ValidationAttribute(() => QowaivValidationMessages.Length_AtMost_ValidationError)
     {

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/Length.InRangeAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/Length.InRangeAttribute.cs
@@ -5,6 +5,7 @@ public static partial class Length
 {
     /// <summary>Specifies the allowed range of the length of property, field or parameter.</summary>
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
+    [Validates(typeof(object))]
     public sealed class InRangeAttribute(long minimum, long maximum)
         : ValidationAttribute(() => QowaivValidationMessages.Length_InRange_ValidationError)
     {

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/MandatoryAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/MandatoryAttribute.cs
@@ -4,6 +4,7 @@ namespace Qowaiv.Validation.DataAnnotations;
 
 /// <summary>Specifies that a field is mandatory (for value types the default value is not allowed).</summary>
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
+[Validates(typeof(object))]
 public sealed class MandatoryAttribute : RequiredAttribute
 {
     /// <summary>Initializes a new instance of the <see cref="MandatoryAttribute"/> class.</summary>
@@ -21,9 +22,9 @@ public sealed class MandatoryAttribute : RequiredAttribute
 
     /// <inheritdoc />
     [Pure]
-    protected override ValidationResult IsValid(object? value, ValidationContext validationContext)
+    protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
         => IsValid(value, GetMemberType(Guard.NotNull(validationContext)))
-        ? ValidationResult.Success!
+        ? null
         : ValidationMessage.Error(FormatErrorMessage(validationContext.DisplayName), validationContext.MemberNames());
 
     /// <summary>Gets the type of the field/property.</summary>

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/MultipleOfAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/MultipleOfAttribute.cs
@@ -4,6 +4,13 @@ namespace Qowaiv.Validation.DataAnnotations;
 
 /// <summary>Specifies that a field is a multiple of a factor.</summary>
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
+[Validates(typeof(float))]
+[Validates(typeof(double))]
+[Validates(typeof(decimal))]
+[Validates(typeof(Amount))]
+[Validates(typeof(Money))]
+[Validates(typeof(Percentage))]
+[Validates(typeof(IConvertible))]
 public sealed class MultipleOfAttribute : ValidationAttribute
 {
     /// <summary>Initializes a new instance of the <see cref="MultipleOfAttribute"/> class.</summary>
@@ -28,19 +35,18 @@ public sealed class MultipleOfAttribute : ValidationAttribute
 
     /// <inheritdoc />
     [Pure]
-    public override bool IsValid(object? value)
-        => value is null
-        || value switch
-        {
-            float flt => IsValid(flt),
-            double dbl => IsValid(dbl),
-            decimal dec => IsValid(dec),
-            Amount amount => IsValid((decimal)amount),
-            Money money => IsValid((decimal)money.Amount),
-            Percentage percentage => IsValid(100 * (decimal)percentage),
-            IConvertible convertible => IsValid(convertible),
-            _ => false,
-        };
+    public override bool IsValid(object? value) => value switch
+    {
+        null => true,
+        float flt => IsValid(flt),
+        double dbl => IsValid(dbl),
+        decimal dec => IsValid(dec),
+        Amount amount => IsValid((decimal)amount),
+        Money money => IsValid((decimal)money.Amount),
+        Percentage percentage => IsValid(100 * (decimal)percentage),
+        IConvertible convertible => IsValid(convertible),
+        _ => throw UnsupportedType.ForAttribute<MultipleOfAttribute>(value.GetType()),
+    };
 
     [Pure]
     private bool IsValid(decimal value) => value % Factor == 0;

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/OptionalAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/OptionalAttribute.cs
@@ -6,6 +6,7 @@ namespace Qowaiv.Validation.DataAnnotations;
 /// See: https://en.wikipedia.org/wiki/Null_object_pattern.
 /// </remarks>
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
+[Validates(typeof(object))]
 public sealed class OptionalAttribute : RequiredAttribute
 {
     /// <summary>Gets a (singleton) <see cref="OptionalAttribute"/>.</summary>

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/Size.AtLeastAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/Size.AtLeastAttribute.cs
@@ -1,4 +1,5 @@
 using Qowaiv.IO;
+using System.IO;
 
 namespace Qowaiv.Validation.DataAnnotations;
 
@@ -7,6 +8,10 @@ public static partial class Size
 {
     /// <summary>Specifies the minimum the size of property, field or parameter.</summary>
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
+    [Validates(typeof(Stream))]
+    [Validates(typeof(ICollection<byte>))]
+    [Validates(typeof(IReadOnlyCollection<byte>))]
+    [Validates("System.BinaryData")]
     public sealed class AtLeastAttribute(long minimum)
         : ValidationAttribute(() => QowaivValidationMessages.Size_AtLeast_ValidationError)
     {

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/Size.AtMostAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/Size.AtMostAttribute.cs
@@ -1,4 +1,5 @@
 using Qowaiv.IO;
+using System.IO;
 
 namespace Qowaiv.Validation.DataAnnotations;
 
@@ -7,6 +8,10 @@ public static partial class Size
 {
     /// <summary>Specifies the maximum the length of property, field or parameter.</summary>
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
+    [Validates(typeof(Stream))]
+    [Validates(typeof(ICollection<byte>))]
+    [Validates(typeof(IReadOnlyCollection<byte>))]
+    [Validates("System.BinaryData")]
     public sealed class AtMostAttribute(long maximum)
         : ValidationAttribute(() => QowaivValidationMessages.Size_AtMost_ValidationError)
     {

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/Size.InRangeAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/Size.InRangeAttribute.cs
@@ -1,4 +1,5 @@
 using Qowaiv.IO;
+using System.IO;
 
 namespace Qowaiv.Validation.DataAnnotations;
 
@@ -7,6 +8,10 @@ public static partial class Size
 {
     /// <summary>Specifies the allowed range of the size of property, field or parameter.</summary>
     [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
+    [Validates(typeof(Stream))]
+    [Validates(typeof(ICollection<byte>))]
+    [Validates(typeof(IReadOnlyCollection<byte>))]
+    [Validates("System.BinaryData")]
     public sealed class InRangeAttribute(long minimum, long maximum)
         : ValidationAttribute(() => QowaivValidationMessages.Size_InRange_ValidationError)
     {

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/UniqueAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/UniqueAttribute.cs
@@ -2,6 +2,7 @@ namespace Qowaiv.Validation.DataAnnotations;
 
 /// <summary>Specifies that all values are distinct.</summary>
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
+[Validates(GenericArgument = true)]
 public sealed class UniqueAttribute<TValue> : ValidationAttribute
 {
     /// <summary>Initializes a new instance of the <see cref="UniqueAttribute{TValue}"/> class.</summary>

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/ValidatesAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/ValidatesAttribute.cs
@@ -1,0 +1,29 @@
+namespace Qowaiv.Validation.DataAnnotations;
+
+/// <summary>
+/// Describes the type the <see cref="ValidationAttribute"/>
+/// is capable of validating.
+/// </summary>
+[CLSCompliant(false)]
+[Conditional("CONTRACTS_FULL")]
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
+public sealed class ValidatesAttribute : Attribute
+{
+    /// <summary>Initializes a new instance of the <see cref="ValidatesAttribute"/> class.</summary>
+    public ValidatesAttribute() : this(typeof(object)) { }
+
+    /// <summary>Initializes a new instance of the <see cref="ValidatesAttribute"/> class.</summary>
+    public ValidatesAttribute(string typeName) => Type = Type.GetType(typeName) ?? typeof(object);
+
+    /// <summary>Initializes a new instance of the <see cref="ValidatesAttribute"/> class.</summary>
+    public ValidatesAttribute(Type type) => Type = type;
+
+    /// <summary>Type that can be validated.</summary>
+    public Type Type { get; }
+
+    /// <summary>
+    /// If true, the type should be equal to the generic to the generic
+    /// argument of the <see cref="ValidationAttribute"/>.
+    /// </summary>
+    public bool GenericArgument { get; init; }
+}

--- a/src/Qowaiv.Validation.DataAnnotations/Qowaiv.Validation.DataAnnotations.csproj
+++ b/src/Qowaiv.Validation.DataAnnotations/Qowaiv.Validation.DataAnnotations.csproj
@@ -14,6 +14,7 @@ v4.0.0
 - Support requiredness via the required modifier.
 - Introduction of [Items<TValidator>] to define a validator on the items of a collection.
 - Introduction of [SkipValidation] to explictly skip validation of types and properties.
+- Introduction of the [Validates(type)] attribute to decorate [Validation] attributes.
 - Qowaiv.Validation.DataAnnotations.ValidationMessage.None returns null. (BREAKING)
 - Refactor annotations resolving.
 - Marked AnnotatedModel as obsolete.

--- a/src/Qowaiv.Validation.DataAnnotations/README.md
+++ b/src/Qowaiv.Validation.DataAnnotations/README.md
@@ -197,6 +197,6 @@ public class Model
 ```
 
 ### Validates attribute
-The `[Validates]`` attribute is designed to help the [QW0102](https://github.com/Qowaiv/qowaiv-analyzers/blob/main/rules/QW0102.md)
+The `[Validates]` attribute is designed to help the [QW0102](https://github.com/Qowaiv/qowaiv-analyzers/blob/main/rules/QW0102.md)
 to report on misusage of the attribute. By decorating an `[Validation]` attribute
 the analyzer knows on which member types the attribute can be set.

--- a/src/Qowaiv.Validation.DataAnnotations/README.md
+++ b/src/Qowaiv.Validation.DataAnnotations/README.md
@@ -195,3 +195,8 @@ public class Model
     public IEnumerable<int> Numbers { get; set; }
 }
 ```
+
+### Validates attribute
+The `[Validates]`` attribute is designed to help the [QW0102](https://github.com/Qowaiv/qowaiv-analyzers/blob/main/rules/QW0102.md)
+to report on misusage of the attribute. By decorating an `[Validation]` attribute
+the analyzer knows on which member types the attribute can be set.


### PR DESCRIPTION
The `[Validates]` attribute is designed to help the [QW0102](https://github.com/Qowaiv/qowaiv-analyzers/pull/59)
to report on misusage of the attribute. By decorating an `[Validation]` attribute the analyzer knows on which member types the attribute can be set.