### PR TITLE
Add clock related attributes

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,13 +6,13 @@
     <CentralPackageVersionOverrideEnabled>true</CentralPackageVersionOverrideEnabled>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="AsyncFixer" Version="*" />
+    <PackageVersion Include="AsyncFixer" Version="1.6.0" />
     <PackageVersion Include="AwesomeAssertions" Version="8.0.2" />
     <PackageVersion Include="AwesomeAssertions.Analyzers" Version="0.34.2" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
-    <PackageVersion Include="DotNetProjectFile.Analyzers" Version="*" />
-    <PackageVersion Include="DotNetProjectFile.Analyzers.Sdk" Version="*" />
+    <PackageVersion Include="DotNetProjectFile.Analyzers" Version="1.5.12" />
+    <PackageVersion Include="DotNetProjectFile.Analyzers.Sdk" Version="1.5.12" />
     <PackageVersion Include="FluentValidation" Version="11.11.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="*" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
@@ -20,8 +20,8 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="*" />
     <PackageVersion Include="Microsoft.Sbom.Targets" Version="3.1.0" />
     <PackageVersion Include="NUnit" Version="4.3.2" />
-    <PackageVersion Include="NUnit.Analyzers" Version="*" />
-    <PackageVersion Include="NUnit3TestAdapter" Version="*" />
+    <PackageVersion Include="NUnit.Analyzers" Version="4.6.0" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="5.0.0" />
     <PackageVersion Include="PolySharp" Version="1.15.0" />
     <PackageVersion Include="Qowaiv" Version="7.2.3" />
     <PackageVersion Include="Qowaiv.Analyzers.CSharp" Version="2.0.5" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -24,7 +24,7 @@
     <PackageVersion Include="NUnit3TestAdapter" Version="*" />
     <PackageVersion Include="PolySharp" Version="1.15.0" />
     <PackageVersion Include="Qowaiv" Version="7.2.3" />
-    <PackageVersion Include="Qowaiv.Analyzers.CSharp" Version="*" />
+    <PackageVersion Include="Qowaiv.Analyzers.CSharp" Version="2.0.5" />
     <PackageVersion Include="Qowaiv.Diagnostics.Contracts" Version="2.0.5" />
     <PackageVersion Include="Qowaiv.TestTools" Version="8.0.0" />
     <PackageVersion Include="SonarAnalyzer.CSharp" Version="*" />

--- a/specs/Qowaiv.Validation.Specs/Data_Annotations/Attributes/Clock_specs.cs
+++ b/specs/Qowaiv.Validation.Specs/Data_Annotations/Attributes/Clock_specs.cs
@@ -1,0 +1,206 @@
+using FluentAssertions.Extensions;
+using Qowaiv.Validation.DataAnnotations;
+
+namespace Data_annotations.Attributes.Clock_specs;
+
+public class InFuture
+{
+    public class Guards
+    {
+        [TestCase("2017-06-11T06:16")]
+        [TestCase("2048-03-14T15:00")]
+        public void DateTime(DateTime d)
+        {
+            using var clock = Clock.SetTimeForCurrentContext(() => 11.June(2017).At(06, 15));
+            new InFutureAttribute().IsValid(d).Should().BeTrue();
+        }
+
+        [TestCase("2017-06-11T06:16+00:00")]
+        [TestCase("2048-03-14T15:00")]
+        public void DateTimeOffset(DateTimeOffset d)
+        {
+            using var clock = Clock.SetTimeAndTimeZoneForCurrentContext(() => 11.June(2017).At(06, 15), TimeZoneInfo.Utc);
+            new InFutureAttribute().IsValid(d).Should().BeTrue();
+        }
+
+        [TestCase("2017-06-12")]
+        [TestCase("2048-03-14")]
+        public void Date(Date d)
+        {
+            using var clock = Clock.SetTimeForCurrentContext(() => 11.June(2017).At(06, 15));
+            new InFutureAttribute().IsValid(d).Should().BeTrue();
+        }
+
+        [TestCase("2017-06-12")]
+        [TestCase("2048-03-14")]
+        public void Date(DateOnly d)
+        {
+            using var clock = Clock.SetTimeForCurrentContext(() => 11.June(2017).At(06, 15));
+            new InFutureAttribute().IsValid(d).Should().BeTrue();
+        }
+
+        [TestCase(2018)]
+        [TestCase(2048)]
+        public void Year(Year year)
+        {
+            using var clock = Clock.SetTimeForCurrentContext(() => 11.June(2017).At(06, 15));
+            new InFutureAttribute().IsValid(year).Should().BeTrue();
+        }
+    }
+}
+
+public class InPast
+{
+    public class Guards
+    {
+        [TestCase("2017-06-11T06:14")]
+        [TestCase("1999-03-14T15:00")]
+        public void DateTime(DateTime d)
+        {
+            using var clock = Clock.SetTimeForCurrentContext(() => 11.June(2017).At(06, 15));
+            new InPastAttribute().IsValid(d).Should().BeTrue();
+        }
+
+        [TestCase("2017-06-11T06:14+00:00")]
+        [TestCase("1999-03-14T15:00")]
+        public void DateTimeOffset(DateTimeOffset d)
+        {
+            using var clock = Clock.SetTimeAndTimeZoneForCurrentContext(() => 11.June(2017).At(06, 15), TimeZoneInfo.Utc);
+            new InPastAttribute().IsValid(d).Should().BeTrue();
+        }
+
+        [TestCase("2017-06-10")]
+        [TestCase("1999-03-14")]
+        public void Date(Date d)
+        {
+            using var clock = Clock.SetTimeForCurrentContext(() => 11.June(2017).At(06, 15));
+            new InPastAttribute().IsValid(d).Should().BeTrue();
+        }
+
+        [TestCase("2017-06-10")]
+        [TestCase("1999-03-14")]
+        public void Date(DateOnly d)
+        {
+            using var clock = Clock.SetTimeForCurrentContext(() => 11.June(2017).At(06, 15));
+            new InPastAttribute().IsValid(d).Should().BeTrue();
+        }
+
+        [TestCase(2016)]
+        [TestCase(1999)]
+        public void Year(Year year)
+        {
+            using var clock = Clock.SetTimeForCurrentContext(() => 11.June(2017).At(06, 15));
+            new InPastAttribute().IsValid(year).Should().BeTrue();
+        }
+    }
+}
+
+public class NotInFuture
+{
+    public class Guards
+    {
+        [TestCase("2017-06-11T06:14")]
+        [TestCase("2017-06-11T06:15")]
+        [TestCase("1999-03-14T15:00")]
+        public void DateTime(DateTime d)
+        {
+            using var clock = Clock.SetTimeForCurrentContext(() => 11.June(2017).At(06, 15));
+            new NotInFutureAttribute().IsValid(d).Should().BeTrue();
+        }
+
+        [TestCase("2017-06-11T06:14+00:00")]
+        [TestCase("2017-06-11T06:15+00:00")]
+        [TestCase("1999-03-14T15:00")]
+        public void DateTimeOffset(DateTimeOffset d)
+        {
+            using var clock = Clock.SetTimeAndTimeZoneForCurrentContext(() => 11.June(2017).At(06, 15), TimeZoneInfo.Utc);
+            new NotInFutureAttribute().IsValid(d).Should().BeTrue();
+        }
+
+        [TestCase("2017-06-10")]
+        [TestCase("2017-06-11")]
+        [TestCase("1999-03-14")]
+        public void Date(Date d)
+        {
+            using var clock = Clock.SetTimeForCurrentContext(() => 11.June(2017).At(06, 15));
+            new NotInFutureAttribute().IsValid(d).Should().BeTrue();
+        }
+
+        [TestCase("2017-06-10")]
+        [TestCase("2017-06-11")]
+        [TestCase("1999-03-14")]
+        public void Date(DateOnly d)
+        {
+            using var clock = Clock.SetTimeForCurrentContext(() => 11.June(2017).At(06, 15));
+            new NotInFutureAttribute().IsValid(d).Should().BeTrue();
+        }
+
+        [TestCase(2016)]
+        [TestCase(2017)]
+        [TestCase(1999)]
+        public void Year(Year year)
+        {
+            using var clock = Clock.SetTimeForCurrentContext(() => 11.June(2017).At(06, 15));
+            new NotInFutureAttribute().IsValid(year).Should().BeTrue();
+        }
+    }
+}
+
+public class NotInPast
+{
+    public class Guards
+    {
+        [TestCase("2017-06-11T06:15")]
+        [TestCase("2017-06-11T06:16")]
+        [TestCase("2048-03-14T15:00")]
+        public void DateTime(DateTime d)
+        {
+            using var clock = Clock.SetTimeForCurrentContext(() => 11.June(2017).At(06, 15));
+            new NotInPastAttribute().IsValid(d).Should().BeTrue();
+        }
+
+        [TestCase("2017-06-11T06:15+00:00")]
+        [TestCase("2017-06-11T06:16+00:00")]
+        [TestCase("2048-03-14T15:00")]
+        public void DateTimeOffset(DateTimeOffset d)
+        {
+            using var clock = Clock.SetTimeAndTimeZoneForCurrentContext(() => 11.June(2017).At(06, 15), TimeZoneInfo.Utc);
+            new NotInPastAttribute().IsValid(d).Should().BeTrue();
+        }
+
+        [TestCase("2017-06-11")]
+        [TestCase("2017-06-12")]
+        [TestCase("2048-03-14")]
+        public void Date(Date d)
+        {
+            using var clock = Clock.SetTimeForCurrentContext(() => 11.June(2017).At(06, 15));
+            new NotInPastAttribute().IsValid(d).Should().BeTrue();
+        }
+
+        [TestCase("2017-06-11")]
+        [TestCase("2017-06-12")]
+        [TestCase("2048-03-14")]
+        public void Date(DateOnly d)
+        {
+            using var clock = Clock.SetTimeForCurrentContext(() => 11.June(2017).At(06, 15));
+            new NotInPastAttribute().IsValid(d).Should().BeTrue();
+        }
+
+        [TestCase(2017)]
+        [TestCase(2018)]
+        [TestCase(2048)]
+        public void Year(Year year)
+        {
+            using var clock = Clock.SetTimeForCurrentContext(() => 11.June(2017).At(06, 15));
+            new NotInPastAttribute().IsValid(year).Should().BeTrue();
+        }
+    }
+}
+
+public class Years
+{
+    [TestCase(null)]
+    [TestCase("?")]
+    public void are_ignored_when(Year year)
+        => new InPastAttribute().IsValid(year).Should().BeTrue();
+}

--- a/specs/Qowaiv.Validation.Specs/Data_Annotations/Attributes/Clock_specs.cs
+++ b/specs/Qowaiv.Validation.Specs/Data_Annotations/Attributes/Clock_specs.cs
@@ -47,8 +47,20 @@ public class InFuture
             new InFutureAttribute().IsValid(year).Should().BeTrue();
         }
     }
-}
 
+    [TestCase("nl", "De waarde van het ExpiryDate veld moet in de toekomst liggen.")]
+    [TestCase("en", "The value of the ExpiryDate field should be in the future.")]
+    public void fails_with_message(CultureInfo culture, string message)
+    {
+        using var clock = Clock.SetTimeForCurrentContext(() => 11.June(2017).At(06, 15));
+        using var _ = culture.Scoped();
+        new Model.ClockDependent.InFuture { ExpiryDate = new(2017, 06, 10) }
+            .ValidateAnnotations()
+            .Should()
+            .BeInvalid()
+            .WithMessage(ValidationMessage.Error(message, "ExpiryDate"));
+    }
+}
 public class InPast
 {
     public class Guards
@@ -92,6 +104,19 @@ public class InPast
             using var clock = Clock.SetTimeForCurrentContext(() => 11.June(2017).At(06, 15));
             new InPastAttribute().IsValid(year).Should().BeTrue();
         }
+    }
+
+    [TestCase("nl", "De waarde van het YearOfConstruction veld moet in het verleden liggen.")]
+    [TestCase("en", "The value of the YearOfConstruction field should be in the past.")]
+    public void fails_with_message(CultureInfo culture, string message)
+    {
+        using var clock = Clock.SetTimeForCurrentContext(() => 11.June(2017).At(06, 15));
+        using var _ = culture.Scoped();
+        new Model.ClockDependent.InPast { YearOfConstruction = 2017.CE() }
+            .ValidateAnnotations()
+            .Should()
+            .BeInvalid()
+            .WithMessage(ValidationMessage.Error(message, "YearOfConstruction"));
     }
 }
 
@@ -144,6 +169,19 @@ public class NotInFuture
             new NotInFutureAttribute().IsValid(year).Should().BeTrue();
         }
     }
+
+    [TestCase("nl", "De waarde van veld DateOfBirth mag niet in de toekomst liggen.")]
+    [TestCase("en", "The value of the DateOfBirth field should not be in the future.")]
+    public void fails_with_message(CultureInfo culture, string message)
+    {
+        using var clock = Clock.SetTimeForCurrentContext(() => 11.June(2017).At(06, 15));
+        using var _ = culture.Scoped();
+        new Model.ClockDependent.NotInFuture { DateOfBirth = new(2018, 06, 12) }
+            .ValidateAnnotations()
+            .Should()
+            .BeInvalid()
+            .WithMessage(ValidationMessage.Error(message, "DateOfBirth"));
+    }
 }
 
 public class NotInPast
@@ -194,6 +232,19 @@ public class NotInPast
             using var clock = Clock.SetTimeForCurrentContext(() => 11.June(2017).At(06, 15));
             new NotInPastAttribute().IsValid(year).Should().BeTrue();
         }
+    }
+
+    [TestCase("nl", "De waarde van veld ExpiryDate mag niet in het verleden liggen.")]
+    [TestCase("en", "The value of the ExpiryDate field should not be in the past.")]
+    public void fails_with_message(CultureInfo culture, string message)
+    {
+        using var clock = Clock.SetTimeForCurrentContext(() => 11.June(2017).At(06, 15));
+        using var _ = culture.Scoped();
+        new Model.ClockDependent.NotInPast { ExpiryDate = new(2017, 06, 10) }
+            .ValidateAnnotations()
+            .Should()
+            .BeInvalid()
+            .WithMessage(ValidationMessage.Error(message, "ExpiryDate"));
     }
 }
 

--- a/specs/Qowaiv.Validation.Specs/Data_Annotations/Model.cs
+++ b/specs/Qowaiv.Validation.Specs/Data_Annotations/Model.cs
@@ -7,6 +7,32 @@ namespace Data_annotations;
 
 internal static class Model
 {
+    public static class ClockDependent
+    {
+        public sealed class InFuture
+        {
+            [InFuture]
+            public DateOnly? ExpiryDate { get; init; }
+        }
+
+        public sealed class InPast
+        {
+            [InPast]
+            public Year YearOfConstruction { get; init; }
+        }
+
+        public sealed class NotInFuture
+        {
+            [NotInFuture]
+            public DateOnly DateOfBirth { get; init; }
+        }
+
+        public sealed class NotInPast
+        {
+            [NotInPast]
+            public DateOnly ExpiryDate { get; init; }
+        }
+    }
     public static class With
     {
         public sealed class AnnotatedProperty

--- a/src/Qowaiv.Validation.DataAnnotations/Annotations/MemberAnnotations.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Annotations/MemberAnnotations.cs
@@ -54,5 +54,4 @@ internal readonly struct MemberAnnotations
         => Store.Get(Guard.NotNull(type), []);
 
     private static readonly AnnotationStore Store = new();
-
 }

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/AllowedAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/AllowedAttribute.cs
@@ -1,7 +1,7 @@
 namespace Qowaiv.Validation.DataAnnotations;
 
 /// <summary>Validates if the decorated item has a value that is specified in the allowed values.</summary>
-[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
+[AttributeUsage(AttributeTarget.Member, AllowMultiple = false)]
 [CLSCompliant(false)]
 [Validates(GenericArgument = true)]
 public sealed class AllowedAttribute<TValue>(params object[] values) : SetOfAttribute<TValue>(values)

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/AnyAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/AnyAttribute.cs
@@ -1,7 +1,7 @@
 namespace Qowaiv.Validation.DataAnnotations;
 
 /// <summary>Specifies that a field should at least have one item in its collection.</summary>
-[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
+[AttributeUsage(AttributeTarget.Member, AllowMultiple = false)]
 [Validates(typeof(IEnumerable))]
 public class AnyAttribute : RequiredAttribute
 {

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/AttributeTarget.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/AttributeTarget.cs
@@ -1,0 +1,9 @@
+namespace Qowaiv.Validation.DataAnnotations;
+
+/// <summary>Helper for centralizing <see cref="AttributeTargets" /> combinations.</summary>
+internal static class AttributeTarget
+{
+    /// <summary>
+    /// <see cref="AttributeTargets.Property" /> | <see cref="AttributeTargets.Field" /> | <see cref="AttributeTargets.Parameter" />.</summary>
+    public const AttributeTargets Member = AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter;
+}

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/ClockAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/ClockAttribute.cs
@@ -1,0 +1,28 @@
+namespace Qowaiv.Validation.DataAnnotations;
+
+/// <summary>Base attribute for validating members compared to the clock.</summary>
+[CLSCompliant(false)]
+public abstract class ClockAttribute(Func<string> errorMessageAccessor) : ValidationAttribute(errorMessageAccessor)
+{
+    /// <inheritdoc />
+    [Pure]
+    public sealed override bool IsValid(object? value) => value switch
+    {
+        null => true,
+        Year y when y.IsEmptyOrUnknown() => true,
+
+        DateTime d /*.*/ => ValidateCompare(d.CompareTo(Clock.UtcNow())),
+        DateTimeOffset d => ValidateCompare(d.CompareTo(Clock.Now())),
+
+        Date d /*.....*/ => ValidateCompare(d.CompareTo(Clock.Today())),
+#if NET8_0_OR_GREATER
+        DateOnly d /*.*/ => ValidateCompare(d.CompareTo(Clock.Today())),
+#endif
+        Year y /*.....*/ => ValidateCompare(y.CompareTo(Clock.Today().Year)),
+        _ => false,
+    };
+
+    /// <summary>Validates the outcome of the compare.</summary>
+    [Pure]
+    protected abstract bool ValidateCompare(int compare);
+}

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/ClockAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/ClockAttribute.cs
@@ -18,7 +18,7 @@ public abstract class ClockAttribute(Func<string> errorMessageAccessor) : Valida
 #if NET8_0_OR_GREATER
         DateOnly d /*.*/ => ValidateCompare(d.CompareTo(Clock.Today())),
 #endif
-        Year y /*.....*/ => ValidateCompare(y.CompareTo(Clock.Today().Year)),
+        Year y /*.....*/ => ValidateCompare(y.CompareTo(Clock.Today().Year.CE())),
         _ => false,
     };
 

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/Collection.AtLeastAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/Collection.AtLeastAttribute.cs
@@ -4,7 +4,7 @@ namespace Qowaiv.Validation.DataAnnotations;
 public static partial class Collection
 {
     /// <summary>Specifies the minimum the length of property, field or parameter.</summary>
-    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
+    [AttributeUsage(AttributeTarget.Member, AllowMultiple = false)]
     [Validates(typeof(object))]
     public sealed class AtLeastAttribute(long minimum)
         : ValidationAttribute(() => QowaivValidationMessages.Collection_AtLeast_ValidationError)

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/Collection.AtMostAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/Collection.AtMostAttribute.cs
@@ -4,7 +4,7 @@ namespace Qowaiv.Validation.DataAnnotations;
 public static partial class Collection
 {
     /// <summary>Specifies the maximum the length of property, field or parameter.</summary>
-    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
+    [AttributeUsage(AttributeTarget.Member, AllowMultiple = false)]
     [Validates(typeof(object))]
     public sealed class AtMostAttribute(long maximum)
         : ValidationAttribute(() => QowaivValidationMessages.Collection_AtMost_ValidationError)

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/Collection.InRangeAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/Collection.InRangeAttribute.cs
@@ -4,7 +4,7 @@ namespace Qowaiv.Validation.DataAnnotations;
 public static partial class Collection
 {
     /// <summary>Specifies the allowed range of the length of property, field or parameter.</summary>
-    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
+    [AttributeUsage(AttributeTarget.Member, AllowMultiple = false)]
     [Validates(typeof(object))]
     public sealed class InRangeAttribute(long minimum, long maximum)
         : ValidationAttribute(() => QowaivValidationMessages.Collection_InRange_ValidationError)

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/DefinedOnlyAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/DefinedOnlyAttribute.cs
@@ -6,7 +6,7 @@ namespace Qowaiv.Validation.DataAnnotations;
 /// <typeparam name="TEnum">
 /// The type of the enum.
 /// </typeparam>
-[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
+[AttributeUsage(AttributeTarget.Member, AllowMultiple = false)]
 [Validates(GenericArgument = true)]
 public class DefinedOnlyAttribute<TEnum> : ValidationAttribute
     where TEnum : struct, Enum

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/ForbiddenAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/ForbiddenAttribute.cs
@@ -1,7 +1,7 @@
 namespace Qowaiv.Validation.DataAnnotations;
 
 /// <summary>Validates if the decorated item has a value that is specified in the forbidden values.</summary>
-[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
+[AttributeUsage(AttributeTarget.Member, AllowMultiple = false)]
 [CLSCompliant(false)]
 [Validates(GenericArgument = true)]
 public sealed class ForbiddenAttribute<TValue>(params object[] values) : SetOfAttribute<TValue>(values)

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/InFutureAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/InFutureAttribute.cs
@@ -9,6 +9,7 @@ namespace Qowaiv.Validation.DataAnnotations;
 [Validates(typeof(DateOnly))]
 #endif
 [Validates(typeof(Year))]
+[CLSCompliant(false)]
 public sealed class InFutureAttribute() : ClockAttribute(() => QowaivValidationMessages.InFuture)
 {
     /// <inheritdoc />

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/InFutureAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/InFutureAttribute.cs
@@ -1,0 +1,17 @@
+namespace Qowaiv.Validation.DataAnnotations;
+
+/// <summary>Specifies that the value must be in the future.</summary>
+[AttributeUsage(AttributeTarget.Member, AllowMultiple = false)]
+[Validates(typeof(DateTime))]
+[Validates(typeof(DateTimeOffset))]
+[Validates(typeof(Date))]
+#if NET8_0_OR_GREATER
+[Validates(typeof(DateOnly))]
+#endif
+[Validates(typeof(Year))]
+public sealed class InFutureAttribute() : ClockAttribute(() => QowaivValidationMessages.InFuture)
+{
+    /// <inheritdoc />
+    [Pure]
+    protected override bool ValidateCompare(int compare) => compare > 0;
+}

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/InPastAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/InPastAttribute.cs
@@ -1,0 +1,17 @@
+namespace Qowaiv.Validation.DataAnnotations;
+
+/// <summary>Specifies that the value must be in the past.</summary>
+[AttributeUsage(AttributeTarget.Member, AllowMultiple = false)]
+[Validates(typeof(DateTime))]
+[Validates(typeof(DateTimeOffset))]
+[Validates(typeof(Date))]
+#if NET8_0_OR_GREATER
+[Validates(typeof(DateOnly))]
+#endif
+[Validates(typeof(Year))]
+public sealed class InPastAttribute() : ClockAttribute(() => QowaivValidationMessages.InPast)
+{
+    /// <inheritdoc />
+    [Pure]
+    protected override bool ValidateCompare(int compare) => compare < 0;
+}

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/InPastAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/InPastAttribute.cs
@@ -9,6 +9,7 @@ namespace Qowaiv.Validation.DataAnnotations;
 [Validates(typeof(DateOnly))]
 #endif
 [Validates(typeof(Year))]
+[CLSCompliant(false)]
 public sealed class InPastAttribute() : ClockAttribute(() => QowaivValidationMessages.InPast)
 {
     /// <inheritdoc />

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/IsFiniteAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/IsFiniteAttribute.cs
@@ -1,7 +1,7 @@
 namespace Qowaiv.Validation.DataAnnotations;
 
 /// <summary>Specifies that a field is a finite number.</summary>
-[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
+[AttributeUsage(AttributeTarget.Member, AllowMultiple = false)]
 [Validates(typeof(float))]
 [Validates(typeof(double))]
 public sealed class IsFiniteAttribute : ValidationAttribute

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/ItemsAttributes.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/ItemsAttributes.cs
@@ -4,7 +4,7 @@ namespace Qowaiv.Validation.DataAnnotations;
 /// <typeparam name="TValidator">
 /// The validator to validate the items with.
 /// </typeparam>
-[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = true, Inherited = false)]
+[AttributeUsage(AttributeTarget.Member, AllowMultiple = true, Inherited = false)]
 [CLSCompliant(false)]
 [Validates(typeof(IEnumerable))]
 public class ItemsAttribute<TValidator> : ValidationAttribute

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/Length.AtLeastAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/Length.AtLeastAttribute.cs
@@ -4,7 +4,7 @@ namespace Qowaiv.Validation.DataAnnotations;
 public static partial class Length
 {
     /// <summary>Specifies the minimum the length of property, field or parameter.</summary>
-    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
+    [AttributeUsage(AttributeTarget.Member, AllowMultiple = false)]
     [Validates(typeof(object))]
     public sealed class AtLeastAttribute(long minimum)
         : ValidationAttribute(() => QowaivValidationMessages.Length_AtLeast_ValidationError)

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/Length.AtMostAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/Length.AtMostAttribute.cs
@@ -4,7 +4,7 @@ namespace Qowaiv.Validation.DataAnnotations;
 public static partial class Length
 {
     /// <summary>Specifies the maximum the length of property, field or parameter.</summary>
-    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
+    [AttributeUsage(AttributeTarget.Member, AllowMultiple = false)]
     [Validates(typeof(object))]
     public sealed class AtMostAttribute(long maximum)
         : ValidationAttribute(() => QowaivValidationMessages.Length_AtMost_ValidationError)

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/Length.InRangeAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/Length.InRangeAttribute.cs
@@ -4,7 +4,7 @@ namespace Qowaiv.Validation.DataAnnotations;
 public static partial class Length
 {
     /// <summary>Specifies the allowed range of the length of property, field or parameter.</summary>
-    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
+    [AttributeUsage(AttributeTarget.Member, AllowMultiple = false)]
     [Validates(typeof(object))]
     public sealed class InRangeAttribute(long minimum, long maximum)
         : ValidationAttribute(() => QowaivValidationMessages.Length_InRange_ValidationError)

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/MandatoryAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/MandatoryAttribute.cs
@@ -3,7 +3,7 @@ using Qowaiv.Reflection;
 namespace Qowaiv.Validation.DataAnnotations;
 
 /// <summary>Specifies that a field is mandatory (for value types the default value is not allowed).</summary>
-[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
+[AttributeUsage(AttributeTarget.Member, AllowMultiple = false)]
 [Validates(typeof(object))]
 public sealed class MandatoryAttribute : RequiredAttribute
 {

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/MultipleOfAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/MultipleOfAttribute.cs
@@ -3,7 +3,7 @@ using Qowaiv.Financial;
 namespace Qowaiv.Validation.DataAnnotations;
 
 /// <summary>Specifies that a field is a multiple of a factor.</summary>
-[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
+[AttributeUsage(AttributeTarget.Member, AllowMultiple = false)]
 [Validates(typeof(float))]
 [Validates(typeof(double))]
 [Validates(typeof(decimal))]

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/NotInFutureAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/NotInFutureAttribute.cs
@@ -9,6 +9,7 @@ namespace Qowaiv.Validation.DataAnnotations;
 [Validates(typeof(DateOnly))]
 #endif
 [Validates(typeof(Year))]
+[CLSCompliant(false)]
 public sealed class NotInFutureAttribute() : ClockAttribute(() => QowaivValidationMessages.NotInFuture)
 {
     /// <inheritdoc />

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/NotInFutureAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/NotInFutureAttribute.cs
@@ -1,0 +1,17 @@
+namespace Qowaiv.Validation.DataAnnotations;
+
+/// <summary>Specifies that the value can not be in the future.</summary>
+[AttributeUsage(AttributeTarget.Member, AllowMultiple = false)]
+[Validates(typeof(DateTime))]
+[Validates(typeof(DateTimeOffset))]
+[Validates(typeof(Date))]
+#if NET8_0_OR_GREATER
+[Validates(typeof(DateOnly))]
+#endif
+[Validates(typeof(Year))]
+public sealed class NotInFutureAttribute() : ClockAttribute(() => QowaivValidationMessages.NotInFuture)
+{
+    /// <inheritdoc />
+    [Pure]
+    protected override bool ValidateCompare(int compare) => compare <= 0;
+}

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/NotInPastAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/NotInPastAttribute.cs
@@ -1,0 +1,17 @@
+namespace Qowaiv.Validation.DataAnnotations;
+
+/// <summary>Specifies that the value can not be in the past.</summary>
+[AttributeUsage(AttributeTarget.Member, AllowMultiple = false)]
+[Validates(typeof(DateTime))]
+[Validates(typeof(DateTimeOffset))]
+[Validates(typeof(Date))]
+#if NET8_0_OR_GREATER
+[Validates(typeof(DateOnly))]
+#endif
+[Validates(typeof(Year))]
+public sealed class NotInPastAttribute() : ClockAttribute(() => QowaivValidationMessages.NotInPast)
+{
+    /// <inheritdoc />
+    [Pure]
+    protected override bool ValidateCompare(int compare) => compare >= 0;
+}

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/NotInPastAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/NotInPastAttribute.cs
@@ -9,6 +9,7 @@ namespace Qowaiv.Validation.DataAnnotations;
 [Validates(typeof(DateOnly))]
 #endif
 [Validates(typeof(Year))]
+[CLSCompliant(false)]
 public sealed class NotInPastAttribute() : ClockAttribute(() => QowaivValidationMessages.NotInPast)
 {
     /// <inheritdoc />

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/OptionalAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/OptionalAttribute.cs
@@ -9,9 +9,6 @@ namespace Qowaiv.Validation.DataAnnotations;
 [Validates(typeof(object))]
 public sealed class OptionalAttribute : RequiredAttribute
 {
-    /// <summary>Gets a (singleton) <see cref="OptionalAttribute"/>.</summary>
-    internal static readonly OptionalAttribute Optional = new();
-
     /// <summary>Returns true as an <see cref="OptionalAttribute"/> is always valid.</summary>
     [Pure]
     public override bool IsValid(object? value) => true;

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/OptionalAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/OptionalAttribute.cs
@@ -5,7 +5,7 @@ namespace Qowaiv.Validation.DataAnnotations;
 /// Null object pattern implementation for a <see cref="RequiredAttribute"/>.
 /// See: https://en.wikipedia.org/wiki/Null_object_pattern.
 /// </remarks>
-[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
+[AttributeUsage(AttributeTarget.Member, AllowMultiple = false)]
 [Validates(typeof(object))]
 public sealed class OptionalAttribute : RequiredAttribute
 {

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/SetOfAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/SetOfAttribute.cs
@@ -4,7 +4,7 @@ namespace Qowaiv.Validation.DataAnnotations;
 /// <typeparam name="TValue">
 /// The type of the value.
 /// </typeparam>
-[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
+[AttributeUsage(AttributeTarget.Member, AllowMultiple = false)]
 [CLSCompliant(false)]
 public abstract class SetOfAttribute<TValue> : ValidationAttribute
 {

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/Size.AtLeastAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/Size.AtLeastAttribute.cs
@@ -7,7 +7,7 @@ namespace Qowaiv.Validation.DataAnnotations;
 public static partial class Size
 {
     /// <summary>Specifies the minimum the size of property, field or parameter.</summary>
-    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
+    [AttributeUsage(AttributeTarget.Member, AllowMultiple = false)]
     [Validates(typeof(Stream))]
     [Validates(typeof(ICollection<byte>))]
     [Validates(typeof(IReadOnlyCollection<byte>))]

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/Size.AtMostAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/Size.AtMostAttribute.cs
@@ -7,7 +7,7 @@ namespace Qowaiv.Validation.DataAnnotations;
 public static partial class Size
 {
     /// <summary>Specifies the maximum the length of property, field or parameter.</summary>
-    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
+    [AttributeUsage(AttributeTarget.Member, AllowMultiple = false)]
     [Validates(typeof(Stream))]
     [Validates(typeof(ICollection<byte>))]
     [Validates(typeof(IReadOnlyCollection<byte>))]

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/Size.InRangeAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/Size.InRangeAttribute.cs
@@ -7,7 +7,7 @@ namespace Qowaiv.Validation.DataAnnotations;
 public static partial class Size
 {
     /// <summary>Specifies the allowed range of the size of property, field or parameter.</summary>
-    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
+    [AttributeUsage(AttributeTarget.Member, AllowMultiple = false)]
     [Validates(typeof(Stream))]
     [Validates(typeof(ICollection<byte>))]
     [Validates(typeof(IReadOnlyCollection<byte>))]

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/SkipValidationAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/SkipValidationAttribute.cs
@@ -1,7 +1,7 @@
 namespace Qowaiv.Validation.DataAnnotations;
 
 /// <summary>Indicates that validation should be skipped.</summary>
-[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false, Inherited = false)]
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false, Inherited = false)]
 public sealed class SkipValidationAttribute(string? justification) : Attribute
 {
     /// <summary>Initializes a new instance of the <see cref="SkipValidationAttribute"/> class.</summary>

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/UniqueAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/UniqueAttribute.cs
@@ -1,7 +1,7 @@
 namespace Qowaiv.Validation.DataAnnotations;
 
 /// <summary>Specifies that all values are distinct.</summary>
-[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter, AllowMultiple = false)]
+[AttributeUsage(AttributeTarget.Member, AllowMultiple = false)]
 [Validates(GenericArgument = true)]
 public sealed class UniqueAttribute<TValue> : ValidationAttribute
 {

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/ValidatesAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/ValidatesAttribute.cs
@@ -7,7 +7,7 @@ namespace Qowaiv.Validation.DataAnnotations;
 [CLSCompliant(false)]
 [Conditional("CONTRACTS_FULL")]
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = true, Inherited = false)]
-public sealed class ValidatesAttribute : Attribute
+public class ValidatesAttribute : Attribute
 {
     /// <summary>Initializes a new instance of the <see cref="ValidatesAttribute"/> class.</summary>
     public ValidatesAttribute() : this(typeof(object)) { }

--- a/src/Qowaiv.Validation.DataAnnotations/Qowaiv.Validation.DataAnnotations.csproj
+++ b/src/Qowaiv.Validation.DataAnnotations/Qowaiv.Validation.DataAnnotations.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="../../props/package.props" />
 

--- a/src/Qowaiv.Validation.DataAnnotations/Qowaiv.Validation.DataAnnotations.csproj
+++ b/src/Qowaiv.Validation.DataAnnotations/Qowaiv.Validation.DataAnnotations.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <Import Project="../../props/package.props" />
 
@@ -12,6 +12,10 @@
 v4.0.0
 - Support primitives of the same type on [ValueOf<TValue>] attributes.
 - Support requiredness via the required modifier.
+- Introduction of [InPast] valiation attribute.
+- Introduction of [InFuture] valiation attribute.
+- Introduction of [NotInPast] valiation attribute.
+- Introduction of [NotInFuture] valiation attribute.
 - Introduction of [Items<TValidator>] to define a validator on the items of a collection.
 - Introduction of [SkipValidation] to explictly skip validation of types and properties.
 - Introduction of the [Validates(type)] attribute to decorate [Validation] attributes.

--- a/src/Qowaiv.Validation.DataAnnotations/QowaivValidationMessages.Designer.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/QowaivValidationMessages.Designer.cs
@@ -115,6 +115,24 @@ namespace Qowaiv.Validation.DataAnnotations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The value of the {0} field should be in the future..
+        /// </summary>
+        internal static string InFuture {
+            get {
+                return ResourceManager.GetString("InFuture", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The value of the {0} field should be in the past,.
+        /// </summary>
+        internal static string InPast {
+            get {
+                return ResourceManager.GetString("InPast", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The value of the {0} field is not a finite number..
         /// </summary>
         internal static string IsFiniteAttribute_ValidationError {
@@ -169,6 +187,24 @@ namespace Qowaiv.Validation.DataAnnotations {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The value of the {0} field should not be in the future..
+        /// </summary>
+        internal static string NotInFuture {
+            get {
+                return ResourceManager.GetString("NotInFuture", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The value of the {0} field should not be in the past..
+        /// </summary>
+        internal static string NotInPast {
+            get {
+                return ResourceManager.GetString("NotInPast", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The size of the {0} field should be at least {1: F}..
         /// </summary>
         internal static string Size_AtLeast_ValidationError {
@@ -194,18 +230,16 @@ namespace Qowaiv.Validation.DataAnnotations {
                 return ResourceManager.GetString("Size_InRange_ValidationError", resourceCulture);
             }
         }
-
+        
         /// <summary>
-        ///   Looks up a localized string similar to All values of the {0} field should be unique.
+        ///   Looks up a localized string similar to All values of the {0} field should be unique..
         /// </summary>
-        internal static string UniqueValuesAttribute_ValidationError
-        {
-            get
-            {
+        internal static string UniqueValuesAttribute_ValidationError {
+            get {
                 return ResourceManager.GetString("UniqueValuesAttribute_ValidationError", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to {0} does not support properties of the type {1}..
         /// </summary>
@@ -216,4 +250,3 @@ namespace Qowaiv.Validation.DataAnnotations {
         }
     }
 }
-

--- a/src/Qowaiv.Validation.DataAnnotations/QowaivValidationMessages.nl.resx
+++ b/src/Qowaiv.Validation.DataAnnotations/QowaivValidationMessages.nl.resx
@@ -9,49 +9,61 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter</value>
   </resheader>
-  <data name="AllowedValuesAttribute_ValidationError" xml:space="preserve">
+  <data name="AllowedValuesAttribute_ValidationError">
     <value>De waarde van het veld {0} is niet toegestaan.</value>
   </data>
-  <data name="Collection_AtLeast_ValidationError" xml:space="preserve">
+  <data name="Collection_AtLeast_ValidationError">
     <value>Veld {0} moet tenminste {1} items bevatten.</value>
   </data>
-  <data name="Collection_AtMost_ValidationError" xml:space="preserve">
+  <data name="Collection_AtMost_ValidationError">
     <value>Veld {0} mag niet meer dan {1} items bevatten.</value>
   </data>
-  <data name="Collection_InRange_ValidationError" xml:space="preserve">
+  <data name="Collection_InRange_ValidationError">
     <value>Het aantal items van veld {0} moet tussen {1} en {2} zitten.</value>
   </data>
-  <data name="DistinctValuesAttribute_ValidationError" xml:space="preserve">
+  <data name="DistinctValuesAttribute_ValidationError">
     <value>Alle waarden van het veld {0} zouden verschillend moeten zijn.</value>
   </data>
-  <data name="IsFiniteAttribute_ValidationError" xml:space="preserve">
+  <data name="InFuture">
+    <value>De waarde van het {0} veld moet in de toekomst liggen.</value>
+  </data>
+  <data name="InPast">
+    <value>De waarde van het {0} veld moet in het verleden liggen.</value>
+  </data>
+  <data name="IsFiniteAttribute_ValidationError">
     <value>De waarde van het {0} veld is geen eindig getal.</value>
   </data>
-  <data name="Length_AtLeast_ValidationError" xml:space="preserve">
+  <data name="Length_AtLeast_ValidationError">
     <value>De lengte van het veld {0} moet minstens {1} zijn.</value>
   </data>
-  <data name="Length_AtMost_ValidationError" xml:space="preserve">
+  <data name="Length_AtMost_ValidationError">
     <value>De lengte van het veld {0} mag niet meer dan {1} zijn.</value>
   </data>
-  <data name="Length_InRange_ValidationError" xml:space="preserve">
+  <data name="Length_InRange_ValidationError">
     <value>De lengte van het veld {0} moet tussen de {1} en {2} zijn.</value>
   </data>
-  <data name="MandatoryAttribute_ValidationError" xml:space="preserve">
+  <data name="MandatoryAttribute_ValidationError">
     <value>Het veld {0} is verplicht.</value>
   </data>
-  <data name="MultipleOfAttribute_ValidationError" xml:space="preserve">
+  <data name="MultipleOfAttribute_ValidationError">
     <value>De waarde van veld {0} is geen veelvoud van {1}.</value>
   </data>
-  <data name="Size_AtLeast_ValidationError" xml:space="preserve">
+  <data name="NotInFuture">
+    <value>De waarde van veld {0} mag niet in de toekomst liggen.</value>
+  </data>
+  <data name="NotInPast">
+    <value>De waarde van veld {0} mag niet in het verleden liggen.</value>
+  </data>
+  <data name="Size_AtLeast_ValidationError">
     <value>De grootte van het veld {0} moet minstens {1: F} zijn.</value>
   </data>
-  <data name="Size_AtMost_ValidationError" xml:space="preserve">
+  <data name="Size_AtMost_ValidationError">
     <value>De grootte van het veld {0} mag niet meer dan {1: F} zijn.</value>
   </data>
-  <data name="Size_InRange_ValidationError" xml:space="preserve">
+  <data name="Size_InRange_ValidationError">
     <value>De grootte van het veld {0} moet tussen de {1: F} en {2: F} zijn.</value>
   </data>
-  <data name="UniqueValuesAttribute_ValidationError" xml:space="preserve">
+  <data name="UniqueValuesAttribute_ValidationError">
     <value>Alle waarden van het veld {0} zouden verschillend moeten zijn.</value>
   </data>
 </root>

--- a/src/Qowaiv.Validation.DataAnnotations/QowaivValidationMessages.resx
+++ b/src/Qowaiv.Validation.DataAnnotations/QowaivValidationMessages.resx
@@ -9,55 +9,67 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter</value>
   </resheader>
-  <data name="AllowedValuesAttribute_ValidationError" xml:space="preserve">
+  <data name="AllowedValuesAttribute_ValidationError">
     <value>The value of the {0} field is not allowed.</value>
   </data>
-  <data name="ArgumentException_TypeIsNotEqualityComparer" xml:space="preserve">
+  <data name="ArgumentException_TypeIsNotEqualityComparer">
     <value>The type {0} does not implement IEqualityComparer or IEqualityComarer&lt;object&gt;.</value>
   </data>
-  <data name="Collection_AtLeast_ValidationError" xml:space="preserve">
+  <data name="Collection_AtLeast_ValidationError">
     <value>The {0} field should have at least {1} items.</value>
   </data>
-  <data name="Collection_AtMost_ValidationError" xml:space="preserve">
+  <data name="Collection_AtMost_ValidationError">
     <value>The {0} field should have at most {1} items.</value>
   </data>
-  <data name="Collection_InRange_ValidationError" xml:space="preserve">
+  <data name="Collection_InRange_ValidationError">
     <value>The number of items of the {0} field should be between {1} and {2}.</value>
   </data>
-  <data name="DistinctValuesAttribute_ValidationError" xml:space="preserve">
+  <data name="DistinctValuesAttribute_ValidationError">
     <value>All values of the {0} field should be distinct.</value>
   </data>
-  <data name="IsFiniteAttribute_ValidationError" xml:space="preserve">
+  <data name="InFuture">
+    <value>The value of the {0} field should be in the future.</value>
+  </data>
+  <data name="InPast">
+    <value>The value of the {0} field should be in the past.</value>
+  </data>
+  <data name="IsFiniteAttribute_ValidationError">
     <value>The value of the {0} field is not a finite number.</value>
   </data>
-  <data name="Length_AtLeast_ValidationError" xml:space="preserve">
+  <data name="Length_AtLeast_ValidationError">
     <value>The length of the {0} field should be at least {1}.</value>
   </data>
-  <data name="Length_AtMost_ValidationError" xml:space="preserve">
+  <data name="Length_AtMost_ValidationError">
     <value>The length of the {0} field should be at most {1}.</value>
   </data>
-  <data name="Length_InRange_ValidationError" xml:space="preserve">
+  <data name="Length_InRange_ValidationError">
     <value>The length of the {0} field should be between {1} and {2}.</value>
   </data>
-  <data name="MandatoryAttribute_ValidationError" xml:space="preserve">
+  <data name="MandatoryAttribute_ValidationError">
     <value>The {0} field is required.</value>
   </data>
-  <data name="MultipleOfAttribute_ValidationError" xml:space="preserve">
+  <data name="MultipleOfAttribute_ValidationError">
     <value>The value of the {0} field is not a multiple of {1}.</value>
   </data>
-  <data name="Size_AtLeast_ValidationError" xml:space="preserve">
+  <data name="NotInFuture">
+    <value>The value of the {0} field should not be in the future.</value>
+  </data>
+  <data name="NotInPast">
+    <value>The value of the {0} field should not be in the past.</value>
+  </data>
+  <data name="Size_AtLeast_ValidationError">
     <value>The size of the {0} field should be at least {1: F}.</value>
   </data>
-  <data name="Size_AtMost_ValidationError" xml:space="preserve">
+  <data name="Size_AtMost_ValidationError">
     <value>The size of the {0} field should be at most {1: F}.</value>
   </data>
-  <data name="Size_InRange_ValidationError" xml:space="preserve">
+  <data name="Size_InRange_ValidationError">
     <value>The size of the {0} field should be between {1: F} and {2: F}.</value>
   </data>
-  <data name="UniqueValuesAttribute_ValidationError" xml:space="preserve">
+  <data name="UniqueValuesAttribute_ValidationError">
     <value>All values of the {0} field should be unique.</value>
   </data>
-  <data name="UnsupportedType_ForAttribute" xml:space="preserve">
+  <data name="UnsupportedType_ForAttribute">
     <value>{0} does not support properties of the type {1}.</value>
   </data>
 </root>

--- a/src/Qowaiv.Validation.DataAnnotations/README.md
+++ b/src/Qowaiv.Validation.DataAnnotations/README.md
@@ -128,7 +128,7 @@ using [`Qowaiv.Clock.UtcNow()`](https://github.com/Qowaiv/Qowaiv/blob/master/REA
 public class Model
 {
     [InFuture]
-    public DateOnly? DateOfDeath { get; init; }
+    public DateOnly? ExpiryDate { get; init; }
 }
 ```
 

--- a/src/Qowaiv.Validation.DataAnnotations/README.md
+++ b/src/Qowaiv.Validation.DataAnnotations/README.md
@@ -62,10 +62,10 @@ valid for the Unknown value, unless that is explicitly allowed.
 public class Model
 {
     [Mandatory(AllowUnknownValue = true)]
-    public EmailAddress Email { get; set; }
+    public EmailAddress Email { get; init; }
 
     [Mandatory()]
-    public string SomeString { get; set; }
+    public string SomeString { get; init; }
 }
 ```
 
@@ -77,7 +77,7 @@ attribute does. It is only valid if the collection contains at least one item.
 public class Model
 {
     [Any()]
-    public List<int> Numbers { get; set; }
+    public List<int> Numbers { get; init; }
 }
 ```
 
@@ -89,7 +89,7 @@ supports type converters to get the allowed values based on a primitive value.
 public class Model
 {
     [Allowed<Country>("DE", "FR", "GB")]
-    public Country CountryOfBirth { get; set; }
+    public Country CountryOfBirth { get; init; }
 }
 ```
 
@@ -101,7 +101,7 @@ supports type converters to get the forbidden values based on a primitive value.
 public class Model
 {
     [Forbidden<Country>("US", "IR")]
-    public Country CountryOfBirth { get; set; }
+    public Country CountryOfBirth { get; init; }
 }
 ```
 
@@ -115,7 +115,33 @@ when dealing with flags, but that can be restricted by setting
 public class Model
 {
     [DefinedOnly<SomeEnum>(OnlyAllowDefinedFlagsCombinations = false)]
-    public SomeEnum CountryOfBirth { get; set; }
+    public SomeEnum CountryOfBirth { get; init; }
+}
+```
+
+# In future
+The `[InFuture]` attributes requires the `DateTime`, `DateTimeOffset`, `Date`,
+`DateOnly`, or `Year` value to be in the future. The current time is resolved
+using [`Qowaiv.Clock.UtcNow()`](https://github.com/Qowaiv/Qowaiv/blob/master/README.md#qowaiv-clock).
+
+``` C#
+public class Model
+{
+    [InFuture]
+    public DateOnly? DateOfDeath { get; init; }
+}
+```
+
+# In past
+The `[InPast]` attributes requires the `DateTime`, `DateTimeOffset`, `Date`,
+`DateOnly`, or `Year` value to be in the past. The current time is resolved
+using [`Qowaiv.Clock.UtcNow()`](https://github.com/Qowaiv/Qowaiv/blob/master/README.md#qowaiv-clock).
+
+``` C#
+public class Model
+{
+    [InPast]
+    public DateOnly DateOfBirth { get; init; }
 }
 ```
 
@@ -145,7 +171,7 @@ represents a finite (e.a. not NaN, or infinity).
 public class Model
 {
     [IsFinite]
-    public double Number { get; set; }
+    public double Number { get; init; }
 }
 ```
 
@@ -158,7 +184,7 @@ type.
 public class Model
 {
     [SkipValidation]
-    public double Number { get; set; }
+    public double Number { get; init; }
 }
 ```
 
@@ -170,9 +196,36 @@ of the specified factor.
 public class Model
 {
     [MultipleOf(0.001)]
-    public Amount Total { get; set; }
+    public Amount Total { get; init; }
 }
 ```
+
+# Not in future
+The `[NotInFuture]` attributes requires the `DateTime`, `DateTimeOffset`, `Date`,
+`DateOnly`, or `Year` value not to be in the future. The current time is resolved
+using [`Qowaiv.Clock.UtcNow()`](https://github.com/Qowaiv/Qowaiv/blob/master/README.md#qowaiv-clock).
+
+``` C#
+public class Model
+{
+    [InFuture]
+    public DateTime CreationTime { get; init; }
+}
+```
+
+# Not in past
+The `[NotInPast]` attributes requires the `DateTime`, `DateTimeOffset`, `Date`,
+`DateOnly`, or `Year` value not to be in the past. The current time is resolved
+using [`Qowaiv.Clock.UtcNow()`](https://github.com/Qowaiv/Qowaiv/blob/master/README.md#qowaiv-clock).
+
+``` C#
+public class Model
+{
+    [InPast]
+    public DateOnly Start { get; init; }
+}
+```
+
 ### Optional 
 The `[Optional]` attribute indicates explicitly that a field is optional.
 
@@ -180,7 +233,7 @@ The `[Optional]` attribute indicates explicitly that a field is optional.
 public class Model
 {
     [Optional]
-    public string? Message { get; set; }
+    public string? Message { get; init; }
 }
 ```
 
@@ -192,7 +245,7 @@ distinct. If needed, a custom `IEqualityComparer<Value>` comparer can be defined
 public class Model
 {
     [Unique<int>(typeof(CustomEqualityComparer))]
-    public IEnumerable<int> Numbers { get; set; }
+    public IEnumerable<int> Numbers { get; init; }
 }
 ```
 

--- a/src/Qowaiv.Validation.TestTools/Assertions/_extensions.cs
+++ b/src/Qowaiv.Validation.TestTools/Assertions/_extensions.cs
@@ -1,5 +1,3 @@
-using System.Runtime.CompilerServices;
-
 namespace Qowaiv.Validation.TestTools;
 
 /// <summary>Contains extension methods for custom assertions in unit tests.</summary>


### PR DESCRIPTION
For `Qowaiv.Validation.Fluent` they already existed, now they also exist for data annotations.