### PR TITLE
Support custom TypeConverter for [Allowed<T>] and [Forbidden<T>]

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,30 +7,30 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="AsyncFixer" Version="1.6.0" />
-    <PackageVersion Include="AwesomeAssertions" Version="9.0.0" />
-    <PackageVersion Include="AwesomeAssertions.Analyzers" Version="9.0.0" />
-    <PackageVersion Include="BenchmarkDotNet" Version="0.15.0" />
+    <PackageVersion Include="AwesomeAssertions" Version="9.1.0" />
+    <PackageVersion Include="AwesomeAssertions.Analyzers" Version="9.0.3" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.15.3" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
-    <PackageVersion Include="DotNetProjectFile.Analyzers" Version="1.6.1" />
-    <PackageVersion Include="DotNetProjectFile.Analyzers.Sdk" Version="1.6.1" />
+    <PackageVersion Include="DotNetProjectFile.Analyzers" Version="1.7.1" />
+    <PackageVersion Include="DotNetProjectFile.Analyzers.Sdk" Version="1.7.1" />
     <PackageVersion Include="FluentValidation" Version="11.11.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="*" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.9" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="*" />
-    <PackageVersion Include="Microsoft.Sbom.Targets" Version="4.0.3" />
+    <PackageVersion Include="Microsoft.Sbom.Targets" Version="4.1.2" />
     <PackageVersion Include="MiniValidation" Version="0.9.2" />
-    <PackageVersion Include="NUnit" Version="4.3.2" />
-    <PackageVersion Include="NUnit.Analyzers" Version="4.8.1" />
-    <PackageVersion Include="NUnit3TestAdapter" Version="5.0.0" />
+    <PackageVersion Include="NUnit" Version="4.4.0" />
+    <PackageVersion Include="NUnit.Analyzers" Version="4.10.0" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="5.1.0" />
     <PackageVersion Include="PolySharp" Version="1.15.0" />
-    <PackageVersion Include="Qowaiv" Version="7.4.3" />
+    <PackageVersion Include="Qowaiv" Version="7.4.4" />
     <PackageVersion Include="Qowaiv.Analyzers.CSharp" Version="2.0.5" />
     <PackageVersion Include="Qowaiv.Diagnostics.Contracts" Version="2.0.6" />
     <PackageVersion Include="Qowaiv.TestTools" Version="8.0.0" />
     <PackageVersion Include="SonarAnalyzer.CSharp" Version="*" />
     <PackageVersion Include="StyleCop.Analyzers" Version="*-*" />
     <PackageVersion Include="System.ComponentModel.Annotations" Version="5.0.0" />
-    <PackageVersion Include="System.Memory.Data" Version="9.0.5" />
+    <PackageVersion Include="System.Memory.Data" Version="9.0.9" />
   </ItemGroup>
 </Project>

--- a/specs/Qowaiv.Validation.Specs/Data_Annotations/Attributes/SetOf_values_specs.cs
+++ b/specs/Qowaiv.Validation.Specs/Data_Annotations/Attributes/SetOf_values_specs.cs
@@ -1,6 +1,8 @@
 using Qowaiv.Financial;
 using Qowaiv.TestTools.Globalization;
 using Qowaiv.Validation.DataAnnotations;
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Data_Annotations.Attributes.SetOf_values_specs;
 
@@ -19,5 +21,19 @@ public class Supports
             new AllowedAttribute<Amount>(42.12, "17.30").Values
                 .Should().BeEquivalentTo([42.12.Amount(), 17.30.Amount()]);
         }
+    }
+
+    [Test]
+    public void custom_type_converter()
+        => new AllowedAttribute<int>('A', 'B'){ TypeConverter = typeof(AsciiConverter) }.Values
+        .Should().BeEquivalentTo([0 + 'A', 0 + 'B']);
+
+    private sealed class AsciiConverter : TypeConverter
+    {
+        public override bool CanConvertFrom(ITypeDescriptorContext? context, Type sourceType)
+            => sourceType == typeof(char);
+
+        public override object? ConvertFrom(ITypeDescriptorContext? context, CultureInfo? culture, object value)
+            => value is char ch ? (int)ch : null;
     }
 }

--- a/specs/Qowaiv.Validation.Specs/Data_Annotations/Attributes/SetOf_values_specs.cs
+++ b/specs/Qowaiv.Validation.Specs/Data_Annotations/Attributes/SetOf_values_specs.cs
@@ -2,7 +2,7 @@ using Qowaiv.Financial;
 using Qowaiv.TestTools.Globalization;
 using Qowaiv.Validation.DataAnnotations;
 using System.ComponentModel;
-using System.Diagnostics.CodeAnalysis;
+using System.Net.Http;
 
 namespace Data_Annotations.Attributes.SetOf_values_specs;
 
@@ -22,6 +22,11 @@ public class Supports
                 .Should().BeEquivalentTo([42.12.Amount(), 17.30.Amount()]);
         }
     }
+
+    [Test]
+    public void HttpMethod_as_TValue()
+        => new AllowedAttribute<HttpMethod>("GET", "POST").Values
+        .Should().BeEquivalentTo([HttpMethod.Get, HttpMethod.Post]);
 
     [Test]
     public void custom_type_converter()

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/SetOfAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/SetOfAttribute.cs
@@ -17,7 +17,11 @@ public abstract class SetOfAttribute<TValue> : ValidationAttribute
     {
         var all = new HashSet<TValue>();
 
-        TypeConverter converter = TypeDescriptor.GetConverter(typeof(TValue));
+        var converter = TypeConverter is not null
+            ? Guard.IsInstanceOf<TypeConverter>(Activator.CreateInstance(TypeConverter))
+            : null;
+
+        converter ??= TypeDescriptor.GetConverter(typeof(TValue));
 
         foreach (var value in values)
         {
@@ -32,6 +36,9 @@ public abstract class SetOfAttribute<TValue> : ValidationAttribute
         }
         Values = all;
     }
+
+    /// <summary>Specify a custom type converter to convert the values to convert.</summary>
+    public Type? TypeConverter { get; init; }
 
     /// <summary>The result to return when the value of <see cref="IsValid(object)" />
     /// equals one of the values of the <see cref="SetOfAttribute{TValue}" />.

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/SetOfAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/SetOfAttribute.cs
@@ -62,7 +62,7 @@ public abstract class SetOfAttribute<TValue> : ValidationAttribute
 
     /// <summary>Resolves the Type converter to use.</summary>
     /// <remarks>
-    /// Because .NET does provide a built-in converter for <see cref="HttpMethod"/>, we do.
+    /// Because .NET doesn't provide a built-in converter for <see cref="HttpMethod"/>, we do.
     /// </remarks>
     [Pure]
     private TypeConverter Converter() => TypeConverter switch

--- a/src/Qowaiv.Validation.DataAnnotations/Qowaiv.Validation.DataAnnotations.csproj
+++ b/src/Qowaiv.Validation.DataAnnotations/Qowaiv.Validation.DataAnnotations.csproj
@@ -4,17 +4,56 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
-    <PackageValidationBaselineVersion>4.0.0</PackageValidationBaselineVersion>
-    <Version>4.0.1</Version>
     <PackageId>Qowaiv.Validation.DataAnnotations</PackageId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Qowaiv" />
+    <PackageReference Include="System.ComponentModel.Annotations" />
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
+    <PackageReference Include="Microsoft.CSharp" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../Qowaiv.Validation.Abstractions/Qowaiv.Validation.Abstractions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="../../shared/Guard.cs" Link="Guard.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Update="QowaivValidationMessages.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>QowaivValidationMessages.resx</DependentUpon>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Update="QowaivValidationMessages.nl.resx" />
+    <EmbeddedResource Update="QowaivValidationMessages.resx">
+      <LastGenOutput>QowaivValidationMessages.Designer.cs</LastGenOutput>
+      <Generator>ResXFileCodeGenerator</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+
+  <PropertyGroup>
+    <PackageValidationBaselineVersion>4.0.0</PackageValidationBaselineVersion>
+    <Version>4.0.2</Version>
     <ToBeReleased>
       <![CDATA[
-v4.0.2
+v4.*
 - ?
 ]]>
     </ToBeReleased>
     <PackageReleaseNotes>
       <![CDATA[
+v4.0.2
+- Support custom TypeConverters for [Allowed<T>] and [Forbidden<T>].
+- Support System.Net.Http.HttpMethod without custom TypeConverter for [Allowed<T>] and [Forbidden<T>].
 v4.0.1
 - Introduction of [InRange<TValue>] valiation attribute.
 v4.0.0
@@ -85,39 +124,6 @@ v0.0.4
 ]]>
     </PackageReleaseNotes>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Qowaiv" />
-    <PackageReference Include="System.ComponentModel.Annotations" />
-  </ItemGroup>
-  
-  <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
-    <PackageReference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="../Qowaiv.Validation.Abstractions/Qowaiv.Validation.Abstractions.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Compile Include="../../shared/Guard.cs" Link="Guard.cs" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Compile Update="QowaivValidationMessages.Designer.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>QowaivValidationMessages.resx</DependentUpon>
-    </Compile>
-  </ItemGroup>
-
-  <ItemGroup>
-    <EmbeddedResource Update="QowaivValidationMessages.nl.resx" />
-    <EmbeddedResource Update="QowaivValidationMessages.resx">
-      <LastGenOutput>QowaivValidationMessages.Designer.cs</LastGenOutput>
-      <Generator>ResXFileCodeGenerator</Generator>
-    </EmbeddedResource>
-  </ItemGroup>
 
 </Project>
  


### PR DESCRIPTION
By defining a custom `TypeConverter`, more flexibility is provided, both for types that lack a (default) type converter, or when extended conversion is needed.

Note that the values are not longer initializes in the constructor, because that is triggered before the init only property is set.