### PR TITLE
Mandatory error message

### DIFF
--- a/specs/Qowaiv.Validation.Specs/Data_Annotations/Attributes/Any_specs.cs
+++ b/specs/Qowaiv.Validation.Specs/Data_Annotations/Attributes/Any_specs.cs
@@ -1,4 +1,5 @@
 using Qowaiv.Validation.DataAnnotations;
+using System.ComponentModel.DataAnnotations;
 
 namespace Data_annotations.Attributes.Any_specs;
 
@@ -35,5 +36,17 @@ public class With_message
     {
         [Any]
         public IEnumerable<string> Values { get; set; } = [];
+    }
+
+    [Test]
+    public void supports_custom_error_message()
+    {
+        var attr = new AnyAttribute
+        {
+            ErrorMessage = "Custom error message"
+        };
+
+        attr.GetValidationMessage(Array.Empty<int>(), new(new object()))!
+            .Message.Should().Be("Custom error message");
     }
 }

--- a/specs/Qowaiv.Validation.Specs/Data_Annotations/Attributes/Mandatory_specs.cs
+++ b/specs/Qowaiv.Validation.Specs/Data_Annotations/Attributes/Mandatory_specs.cs
@@ -72,6 +72,18 @@ public class With_message
         .Should().BeInvalid()
         .WithMessage(ValidationMessage.Error("The IBAN field is required.", "Iban"));
 
+    [Test]
+    public void supports_custom_error_message()
+    {
+        var attr = new MandatoryAttribute
+        {
+            ErrorMessage = "Custom error message" 
+        };
+
+        attr.GetValidationMessage(Guid.Empty, new(new object()))!
+            .Message.Should().Be("Custom error message");
+    }
+
     internal class Model
     {
         [Mandatory]

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/AnyAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/AnyAttribute.cs
@@ -16,8 +16,8 @@ public class AnyAttribute : RequiredAttribute
     /// has any item, otherwise false.
     /// </summary>
     [Pure]
-    public override bool IsValid(object? value)
+    public override bool IsValid(object? value) => this.Validates(()
         => value is IEnumerable enumerable
         ? enumerable.GetEnumerator().MoveNext()
-        : base.IsValid(value);
+        : base.IsValid(value));
 }

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/IsFiniteAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/IsFiniteAttribute.cs
@@ -4,15 +4,8 @@ namespace Qowaiv.Validation.DataAnnotations;
 [AttributeUsage(AttributeTarget.Member, AllowMultiple = false)]
 [Validates(typeof(float))]
 [Validates(typeof(double))]
-public sealed class IsFiniteAttribute : ValidationAttribute
+public sealed class IsFiniteAttribute() : ValidationAttribute(() => QowaivValidationMessages.IsFiniteAttribute_ValidationError)
 {
-    /// <summary>Initializes a new instance of the <see cref="IsFiniteAttribute"/> class.</summary>
-    public IsFiniteAttribute()
-    {
-        ErrorMessageResourceType = typeof(QowaivValidationMessages);
-        ErrorMessageResourceName = nameof(QowaivValidationMessages.IsFiniteAttribute_ValidationError);
-    }
-
     /// <inheritdoc />
     [Pure]
     public override bool IsValid(object? value) => value switch

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/MandatoryAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/MandatoryAttribute.cs
@@ -51,7 +51,7 @@ public sealed class MandatoryAttribute : RequiredAttribute
     public override bool IsValid(object? value) => IsValid(value, null);
 
     [Pure]
-    private bool IsValid(object? value, Type? memberType)
+    private bool IsValid(object? value, Type? memberType) => this.Validates(() =>
     {
         if (value is { })
         {
@@ -68,5 +68,5 @@ public sealed class MandatoryAttribute : RequiredAttribute
             }
         }
         return base.IsValid(value);
-    }
+    });
 }

--- a/src/Qowaiv.Validation.DataAnnotations/Attributes/MultipleOfAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Attributes/MultipleOfAttribute.cs
@@ -18,12 +18,8 @@ public sealed class MultipleOfAttribute : ValidationAttribute
         : this(AsDecimal(factor) ?? throw new ArgumentOutOfRangeException(nameof(factor), "Can not be represented by a decimal.")) { }
 
     /// <summary>Initializes a new instance of the <see cref="MultipleOfAttribute"/> class.</summary>
-    private MultipleOfAttribute(decimal factor)
-    {
-        Factor = factor;
-        ErrorMessageResourceType = typeof(QowaivValidationMessages);
-        ErrorMessageResourceName = nameof(QowaivValidationMessages.MultipleOfAttribute_ValidationError);
-    }
+    private MultipleOfAttribute(decimal factor) : base(() => QowaivValidationMessages.MultipleOfAttribute_ValidationError)
+        => Factor = factor;
 
     /// <summary>The factor of which the value has to be a multiple of.</summary>
     public decimal Factor { get; }

--- a/src/Qowaiv.Validation.DataAnnotations/Extensions/System.ComponentModel.DataAnnotations.ValidationAttribute.cs
+++ b/src/Qowaiv.Validation.DataAnnotations/Extensions/System.ComponentModel.DataAnnotations.ValidationAttribute.cs
@@ -17,4 +17,27 @@ public static class QowaivValidationAttributeExtensions
         var result = NonPublic.ValidationAttribute.IsValid.Invoke(attribute, [value, validationContext]);
         return ValidationMessage.For(result as ValidationResult);
     }
+
+    /// <summary>Validates the attribute.</summary>
+    /// <remarks>
+    /// To support both custom error messages via <see cref="ValidationAttribute.ErrorMessage"/>
+    /// and via the a custom resource, the latter should be reset when setting
+    /// the first. However, when setting <see cref="ValidationAttribute.ErrorMessage"/>
+    /// The <see cref="ValidationAttribute.ErrorMessageResourceName"/> is not
+    /// reset, which would result in a runtime error. This construct is not
+    /// ideal, but it is the only point where we can alter the default
+    /// behavior.
+    /// </remarks>
+    [Pure]
+    internal static bool Validates(this ValidationAttribute attr, Func<bool> isValid)
+    {
+        var result = isValid();
+
+        if (!result && attr.ErrorMessage is { Length: > 0 })
+        {
+            attr.ErrorMessageResourceName = null;
+            attr.ErrorMessageResourceType = null;
+        }
+        return result;
+    }
 }

--- a/src/Qowaiv.Validation.DataAnnotations/Qowaiv.Validation.DataAnnotations.csproj
+++ b/src/Qowaiv.Validation.DataAnnotations/Qowaiv.Validation.DataAnnotations.csproj
@@ -51,7 +51,7 @@ v5.*
     <PackageReleaseNotes>
       <![CDATA[
 v5.0.1
-- All validation attributes support both ErrorMessage as ErrorMessageResourceName and ErrorMessageResourceType. (BUG)
+- Validation attributes support both ErrorMessage as ErrorMessageResourceName and ErrorMessageResourceType. (BUG)
 v5.0.0
 - Add .NET 10.0 target.
 - Drop .NET 5.0, NET6.0, NET7.0 targets. (BREAKING)

--- a/src/Qowaiv.Validation.DataAnnotations/Qowaiv.Validation.DataAnnotations.csproj
+++ b/src/Qowaiv.Validation.DataAnnotations/Qowaiv.Validation.DataAnnotations.csproj
@@ -41,7 +41,7 @@
 
   <PropertyGroup>
     <PackageValidationBaselineVersion>4.0.0</PackageValidationBaselineVersion>
-    <Version>5.0.0</Version>
+    <Version>5.0.1</Version>
     <ToBeReleased>
       <![CDATA[
 v5.*
@@ -50,6 +50,8 @@ v5.*
     </ToBeReleased>
     <PackageReleaseNotes>
       <![CDATA[
+v5.0.1
+- All validation attributes support both ErrorMessage as ErrorMessageResourceName and ErrorMessageResourceType. (BUG)
 v5.0.0
 - Add .NET 10.0 target.
 - Drop .NET 5.0, NET6.0, NET7.0 targets. (BREAKING)


### PR DESCRIPTION
To support custom error messaging Microsoft support allow two ad-hoc scenario's:

``` C#
class Model
{
    [Required(ErrorMessage = "Custom message")]
    public object? Id { get; init; }
}
```

and

``` C#
class Model
{
    [Required(ErrorMessageResourceName = "CustomMesssageId", ErrorMessageResourceType = typeof(Model) )]
    public object? Id { get; init; }
}
```

Validation attributes inheriting from `RequiredAttribute` (both `MandatoryAttribute` and ``AnyAttribute``) use the latter mechanism in the constructor, as the alternative (non ad-hoc) way of using a lambda is not supported by the overloads of `RequiredAttribute`.

Due to other choices made by the .NET team, setting the `ErrorMessage` later (scenario 1) does not reset both properties which cause a runtime error when validating:
> System.InvalidOperationException: Either ErrorMessageString or ErrorMessageResourceName must be set, but not both.
   at System.ComponentModel.DataAnnotations.ValidationAttribute.SetupResourceAccessor()
   at System.ComponentModel.DataAnnotations.ValidationAttribute.FormatErrorMessage(String name)

To solve this issue, a runtime check is added, that resets both when validation fails and `ErrorMessage` has been set.