### PR TITLE
Add notnull constraint

### DIFF
--- a/specs/Benchmarks/Benchmarks.csproj
+++ b/specs/Benchmarks/Benchmarks.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
-    <NoWarn>CS8002</NoWarn>
+    <NoWarn>CS8002;NU1601</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/specs/Qowaiv.Validation.Specs/Data_Annotations/Model.cs
+++ b/specs/Qowaiv.Validation.Specs/Data_Annotations/Model.cs
@@ -75,9 +75,9 @@ internal static class Model
             public static string NonInstance = string.Empty;
 
             [Allowed<int>(42)]
+#pragma warning disable CS0169 // Needed for testing
             private int Private;
-
-            override public string ToString() => $"Answer: {Answer}, NonInstance: {NonInstance}, Private: {Private}";
+#pragma warning restore CS0169
         }
 
         public sealed class RequiredOnValueType

--- a/specs/Qowaiv.Validation.Specs/Data_Annotations/Model.cs
+++ b/specs/Qowaiv.Validation.Specs/Data_Annotations/Model.cs
@@ -77,7 +77,7 @@ internal static class Model
             [Allowed<int>(42)]
             private int Private;
 
-            internal int Access() => Private;
+            override public string ToString() => $"Answer: {Answer}, NonInstance: {NonInstance}, Private: {Private}";
         }
 
         public sealed class RequiredOnValueType

--- a/src/Qowaiv.Validation.Abstractions/CompatibilitySuppressions.xml
+++ b/src/Qowaiv.Validation.Abstractions/CompatibilitySuppressions.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Suppression>
@@ -83,6 +83,90 @@
     <Right>lib/net8.0/Qowaiv.Validation.Abstractions.dll</Right>
   </Suppression>
   <Suppression>
+    <DiagnosticId>CP0014</DiagnosticId>
+    <Target>M:Qowaiv.Validation.Abstractions.Result.For``1(``0,Qowaiv.Validation.Abstractions.IValidationMessage[])&lt;0&gt;:[T:System.Runtime.CompilerServices.NullableAttribute]</Target>
+    <Left>lib/net8.0/Qowaiv.Validation.Abstractions.dll</Left>
+    <Right>lib/net8.0/Qowaiv.Validation.Abstractions.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0014</DiagnosticId>
+    <Target>M:Qowaiv.Validation.Abstractions.Result.For``1(``0,System.Collections.Generic.IEnumerable{Qowaiv.Validation.Abstractions.IValidationMessage})&lt;0&gt;:[T:System.Runtime.CompilerServices.NullableAttribute]</Target>
+    <Left>lib/net8.0/Qowaiv.Validation.Abstractions.dll</Left>
+    <Right>lib/net8.0/Qowaiv.Validation.Abstractions.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0014</DiagnosticId>
+    <Target>M:Qowaiv.Validation.Abstractions.Validator.Empty``1:[T:System.Runtime.CompilerServices.NullableContextAttribute]</Target>
+    <Left>lib/net8.0/Qowaiv.Validation.Abstractions.dll</Left>
+    <Right>lib/net8.0/Qowaiv.Validation.Abstractions.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0014</DiagnosticId>
+    <Target>M:Qowaiv.Validation.Abstractions.Validator.Empty``1&lt;0&gt;:[T:System.Runtime.CompilerServices.NullableAttribute]</Target>
+    <Left>lib/net8.0/Qowaiv.Validation.Abstractions.dll</Left>
+    <Right>lib/net8.0/Qowaiv.Validation.Abstractions.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0014</DiagnosticId>
+    <Target>M:Qowaiv.Validation.Abstractions.Result.For``1(``0,Qowaiv.Validation.Abstractions.IValidationMessage[])&lt;0&gt;:[T:System.Runtime.CompilerServices.NullableAttribute]</Target>
+    <Left>lib/net9.0/Qowaiv.Validation.Abstractions.dll</Left>
+    <Right>lib/net8.0/Qowaiv.Validation.Abstractions.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0014</DiagnosticId>
+    <Target>M:Qowaiv.Validation.Abstractions.Result.For``1(``0,System.Collections.Generic.IEnumerable{Qowaiv.Validation.Abstractions.IValidationMessage})&lt;0&gt;:[T:System.Runtime.CompilerServices.NullableAttribute]</Target>
+    <Left>lib/net9.0/Qowaiv.Validation.Abstractions.dll</Left>
+    <Right>lib/net8.0/Qowaiv.Validation.Abstractions.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0014</DiagnosticId>
+    <Target>M:Qowaiv.Validation.Abstractions.Validator.Empty``1:[T:System.Runtime.CompilerServices.NullableContextAttribute]</Target>
+    <Left>lib/net9.0/Qowaiv.Validation.Abstractions.dll</Left>
+    <Right>lib/net8.0/Qowaiv.Validation.Abstractions.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0014</DiagnosticId>
+    <Target>M:Qowaiv.Validation.Abstractions.Validator.Empty``1&lt;0&gt;:[T:System.Runtime.CompilerServices.NullableAttribute]</Target>
+    <Left>lib/net9.0/Qowaiv.Validation.Abstractions.dll</Left>
+    <Right>lib/net8.0/Qowaiv.Validation.Abstractions.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0016</DiagnosticId>
+    <Target>T:Qowaiv.Validation.Abstractions.Validator:[T:System.Runtime.CompilerServices.NullableAttribute]</Target>
+    <Left>lib/net8.0/Qowaiv.Validation.Abstractions.dll</Left>
+    <Right>lib/net8.0/Qowaiv.Validation.Abstractions.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0016</DiagnosticId>
+    <Target>T:Qowaiv.Validation.Abstractions.Validator:[T:System.Runtime.CompilerServices.NullableContextAttribute]</Target>
+    <Left>lib/net8.0/Qowaiv.Validation.Abstractions.dll</Left>
+    <Right>lib/net8.0/Qowaiv.Validation.Abstractions.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0016</DiagnosticId>
+    <Target>T:Qowaiv.Validation.Abstractions.Validator:[T:System.Runtime.CompilerServices.NullableAttribute]</Target>
+    <Left>lib/net9.0/Qowaiv.Validation.Abstractions.dll</Left>
+    <Right>lib/net8.0/Qowaiv.Validation.Abstractions.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0016</DiagnosticId>
+    <Target>T:Qowaiv.Validation.Abstractions.Validator:[T:System.Runtime.CompilerServices.NullableContextAttribute]</Target>
+    <Left>lib/net9.0/Qowaiv.Validation.Abstractions.dll</Left>
+    <Right>lib/net8.0/Qowaiv.Validation.Abstractions.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
     <DiagnosticId>CP0016</DiagnosticId>
     <Target>M:Qowaiv.Validation.Abstractions.InvalidModelException.#ctor(System.String,System.Exception,System.Collections.Generic.IEnumerable{Qowaiv.Validation.Abstractions.IValidationMessage}):[T:System.Runtime.CompilerServices.NullableContextAttribute]</Target>
     <Left>lib/netstandard2.0/Qowaiv.Validation.Abstractions.dll</Left>
@@ -115,18 +199,6 @@
   <Suppression>
     <DiagnosticId>CP0016</DiagnosticId>
     <Target>M:Qowaiv.Validation.Abstractions.NoValue.For``1&lt;0&gt;:[T:System.Runtime.CompilerServices.NullableAttribute]</Target>
-    <Left>lib/netstandard2.0/Qowaiv.Validation.Abstractions.dll</Left>
-    <Right>lib/net8.0/Qowaiv.Validation.Abstractions.dll</Right>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0016</DiagnosticId>
-    <Target>M:Qowaiv.Validation.Abstractions.Result.For``1(``0,Qowaiv.Validation.Abstractions.IValidationMessage[])&lt;0&gt;:[T:System.Runtime.CompilerServices.NullableAttribute]</Target>
-    <Left>lib/netstandard2.0/Qowaiv.Validation.Abstractions.dll</Left>
-    <Right>lib/net8.0/Qowaiv.Validation.Abstractions.dll</Right>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0016</DiagnosticId>
-    <Target>M:Qowaiv.Validation.Abstractions.Result.For``1(``0,System.Collections.Generic.IEnumerable{Qowaiv.Validation.Abstractions.IValidationMessage})&lt;0&gt;:[T:System.Runtime.CompilerServices.NullableAttribute]</Target>
     <Left>lib/netstandard2.0/Qowaiv.Validation.Abstractions.dll</Left>
     <Right>lib/net8.0/Qowaiv.Validation.Abstractions.dll</Right>
   </Suppression>
@@ -354,18 +426,6 @@
   </Suppression>
   <Suppression>
     <DiagnosticId>CP0016</DiagnosticId>
-    <Target>M:Qowaiv.Validation.Abstractions.Validator.Empty``1:[T:System.Runtime.CompilerServices.NullableContextAttribute]</Target>
-    <Left>lib/netstandard2.0/Qowaiv.Validation.Abstractions.dll</Left>
-    <Right>lib/net8.0/Qowaiv.Validation.Abstractions.dll</Right>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0016</DiagnosticId>
-    <Target>M:Qowaiv.Validation.Abstractions.Validator.Empty``1&lt;0&gt;:[T:System.Runtime.CompilerServices.NullableAttribute]</Target>
-    <Left>lib/netstandard2.0/Qowaiv.Validation.Abstractions.dll</Left>
-    <Right>lib/net8.0/Qowaiv.Validation.Abstractions.dll</Right>
-  </Suppression>
-  <Suppression>
-    <DiagnosticId>CP0016</DiagnosticId>
     <Target>P:Qowaiv.Validation.Abstractions.ValidationMessage.None:[T:System.Runtime.CompilerServices.NullableAttribute]</Target>
     <Left>lib/netstandard2.0/Qowaiv.Validation.Abstractions.dll</Left>
     <Right>lib/net8.0/Qowaiv.Validation.Abstractions.dll</Right>
@@ -489,5 +549,80 @@
     <Target>T:Qowaiv.Validation.Abstractions.ValidationMessageExtensions:[T:System.Runtime.CompilerServices.NullableContextAttribute]</Target>
     <Left>lib/netstandard2.0/Qowaiv.Validation.Abstractions.dll</Left>
     <Right>lib/net8.0/Qowaiv.Validation.Abstractions.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0016</DiagnosticId>
+    <Target>T:Qowaiv.Validation.Abstractions.Validator:[T:System.Runtime.CompilerServices.NullableAttribute]</Target>
+    <Left>lib/netstandard2.0/Qowaiv.Validation.Abstractions.dll</Left>
+    <Right>lib/net8.0/Qowaiv.Validation.Abstractions.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0016</DiagnosticId>
+    <Target>T:Qowaiv.Validation.Abstractions.Validator:[T:System.Runtime.CompilerServices.NullableContextAttribute]</Target>
+    <Left>lib/netstandard2.0/Qowaiv.Validation.Abstractions.dll</Left>
+    <Right>lib/net8.0/Qowaiv.Validation.Abstractions.dll</Right>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0021</DiagnosticId>
+    <Target>M:Qowaiv.Validation.Abstractions.Result.For``1(``0,Qowaiv.Validation.Abstractions.IValidationMessage[])``0:notnull</Target>
+    <Left>lib/net8.0/Qowaiv.Validation.Abstractions.dll</Left>
+    <Right>lib/net8.0/Qowaiv.Validation.Abstractions.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0021</DiagnosticId>
+    <Target>M:Qowaiv.Validation.Abstractions.Result.For``1(``0,System.Collections.Generic.IEnumerable{Qowaiv.Validation.Abstractions.IValidationMessage})``0:notnull</Target>
+    <Left>lib/net8.0/Qowaiv.Validation.Abstractions.dll</Left>
+    <Right>lib/net8.0/Qowaiv.Validation.Abstractions.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0021</DiagnosticId>
+    <Target>M:Qowaiv.Validation.Abstractions.Validator.Empty``1``0:notnull</Target>
+    <Left>lib/net8.0/Qowaiv.Validation.Abstractions.dll</Left>
+    <Right>lib/net8.0/Qowaiv.Validation.Abstractions.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0021</DiagnosticId>
+    <Target>M:Qowaiv.Validation.Abstractions.Result.For``1(``0,Qowaiv.Validation.Abstractions.IValidationMessage[])``0:notnull</Target>
+    <Left>lib/net9.0/Qowaiv.Validation.Abstractions.dll</Left>
+    <Right>lib/net8.0/Qowaiv.Validation.Abstractions.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0021</DiagnosticId>
+    <Target>M:Qowaiv.Validation.Abstractions.Result.For``1(``0,System.Collections.Generic.IEnumerable{Qowaiv.Validation.Abstractions.IValidationMessage})``0:notnull</Target>
+    <Left>lib/net9.0/Qowaiv.Validation.Abstractions.dll</Left>
+    <Right>lib/net8.0/Qowaiv.Validation.Abstractions.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0021</DiagnosticId>
+    <Target>M:Qowaiv.Validation.Abstractions.Validator.Empty``1``0:notnull</Target>
+    <Left>lib/net9.0/Qowaiv.Validation.Abstractions.dll</Left>
+    <Right>lib/net8.0/Qowaiv.Validation.Abstractions.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0021</DiagnosticId>
+    <Target>M:Qowaiv.Validation.Abstractions.Result.For``1(``0,Qowaiv.Validation.Abstractions.IValidationMessage[])``0:notnull</Target>
+    <Left>lib/netstandard2.0/Qowaiv.Validation.Abstractions.dll</Left>
+    <Right>lib/netstandard2.0/Qowaiv.Validation.Abstractions.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0021</DiagnosticId>
+    <Target>M:Qowaiv.Validation.Abstractions.Result.For``1(``0,System.Collections.Generic.IEnumerable{Qowaiv.Validation.Abstractions.IValidationMessage})``0:notnull</Target>
+    <Left>lib/netstandard2.0/Qowaiv.Validation.Abstractions.dll</Left>
+    <Right>lib/netstandard2.0/Qowaiv.Validation.Abstractions.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0021</DiagnosticId>
+    <Target>M:Qowaiv.Validation.Abstractions.Validator.Empty``1``0:notnull</Target>
+    <Left>lib/netstandard2.0/Qowaiv.Validation.Abstractions.dll</Left>
+    <Right>lib/netstandard2.0/Qowaiv.Validation.Abstractions.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
   </Suppression>
 </Suppressions>

--- a/src/Qowaiv.Validation.Abstractions/Qowaiv.Validation.Abstractions.csproj
+++ b/src/Qowaiv.Validation.Abstractions/Qowaiv.Validation.Abstractions.csproj
@@ -7,21 +7,25 @@
     <PackageValidationBaselineVersion>1.0.0</PackageValidationBaselineVersion>
     <Version>2.0.0</Version>
     <PackageId>Qowaiv.Validation.Abstractions</PackageId>
+    <ToBeReleased>
+      <![CDATA[
+      v2.1.0
+- Add notnull constraint to Result.For<T>().
+]]>
+    </ToBeReleased>
     <PackageReleaseNotes>
       <![CDATA[
 v2.0.0
 - Add Result.ThrowIfInvalid().
 - Add .NET 10.0 target.
 - Drop .NET9.0 targets. (BREAKING)
-- Drop public Diagnostics.Contracts. (BREAKING)
-- Drop binary serialization on exceptions. (BREAKING)
 v1.0.0
 - Add .NET 9.0 target.
 - Drop .NET 5.0, NET6.0, NET7.0 targets. (BREAKING)
 - Drop public Diagnostics.Contracts. (BREAKING)
 - Drop binary serialization on exceptions. (BREAKING)
 v0.3.0
-- Add Result&lt;T&gt;.Cast&lt;TOut&gt;(). #61
+- Add Result<T>.Cast<TOut>(). #61
 - Support .NET 7.0. #62
 v0.2.1
 - Nullable anotations. #48
@@ -40,7 +44,7 @@ v0.1.0
 - Improvements on InvalidModelException. #31
 v0.0.5
 - Act() methods on context. #29
-- AsTask() method for Result&lt;T&gt;. #28
+- AsTask() method for Result<T>. #28
 v0.0.4
 - Act() methods have pipe notation alternatives.
 ]]>

--- a/src/Qowaiv.Validation.Abstractions/Result.cs
+++ b/src/Qowaiv.Validation.Abstractions/Result.cs
@@ -61,11 +61,13 @@ public class Result
     /// <summary>Creates a <see cref="Result{T}"/> for the value.</summary>
     [Pure]
     public static Result<T> For<T>(T value, IEnumerable<IValidationMessage> messages)
+        where T : notnull
         => new Result<T>(value, FixedMessages.New(messages)).NotNull();
 
     /// <summary>Creates a <see cref="Result{T}"/> for the value.</summary>
     [Pure]
     public static Result<T> For<T>(T value, params IValidationMessage[] messages)
+        where T : notnull
         => new Result<T>(value, FixedMessages.New(messages)).NotNull();
 
     /// <summary>Creates a result with messages.</summary>

--- a/src/Qowaiv.Validation.Abstractions/Result_TModel.cs
+++ b/src/Qowaiv.Validation.Abstractions/Result_TModel.cs
@@ -1,3 +1,5 @@
+using System.Reflection;
+
 namespace Qowaiv.Validation.Abstractions;
 
 /// <summary>Represents a result of a validation, executed command, etcetera.</summary>
@@ -31,7 +33,7 @@ public sealed class Result<TModel> : Result
 
     /// <summary>Implicitly casts a model to the <see cref="Result"/>.</summary>
     [Pure]
-    public static implicit operator Result<TModel>(TModel model) => For(model);
+    public static implicit operator Result<TModel>(TModel model) => NotNull(model, FixedMessages.Empty);
 
     /// <inheritdoc />
     [Pure]
@@ -99,7 +101,7 @@ public sealed class Result<TModel> : Result
         if (IsValid)
         {
             var outcome = action(Value);
-            return For(Value, ((FixedMessages)Messages).AddRange(outcome.Messages));
+            return NotNull(Value, ((FixedMessages)Messages).AddRange(outcome.Messages));
         }
         else return WithMessages<TModel>(Messages);
     }
@@ -201,7 +203,7 @@ public sealed class Result<TModel> : Result
         if (IsValid)
         {
             var outcome = await action(Value).ConfigureAwait(continueOnCapturedContext);
-            return For(Value, ((FixedMessages)Messages).AddRange(outcome.Messages));
+            return NotNull(Value, ((FixedMessages)Messages).AddRange(outcome.Messages));
         }
         else return WithMessages<TModel>(Messages);
     }
@@ -294,4 +296,8 @@ public sealed class Result<TModel> : Result
     [Pure]
     internal Result<TModel> NotNull()
        => IsValid && Value is null ? throw NoValue.For<TModel>() : this;
+
+    [Pure]
+    private static Result<TModel> NotNull(TModel? value, FixedMessages messages)
+        => new Result<TModel>(value, messages).NotNull();
 }

--- a/src/Qowaiv.Validation.Abstractions/Validator.cs
+++ b/src/Qowaiv.Validation.Abstractions/Validator.cs
@@ -5,10 +5,13 @@ public static class Validator
 {
     /// <summary>Gets an empty <see cref="IValidator{TModel}"/>.</summary>
     [Pure]
-    public static IValidator<TModel> Empty<TModel>() => new EmptyValidator<TModel>();
+    public static IValidator<TModel> Empty<TModel>()
+        where TModel : notnull
+        => new EmptyValidator<TModel>();
 
     /// <summary>Implementation of an empty validator.</summary>
     private sealed class EmptyValidator<TModel> : IValidator<TModel>
+        where TModel : notnull
     {
         /// <inheritdoc />
         [Pure]

--- a/src/Qowaiv.Validation.DataAnnotations/CompatibilitySuppressions.xml
+++ b/src/Qowaiv.Validation.DataAnnotations/CompatibilitySuppressions.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Suppression>

--- a/src/Qowaiv.Validation.Fluent/CompatibilitySuppressions.xml
+++ b/src/Qowaiv.Validation.Fluent/CompatibilitySuppressions.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Suppression>
@@ -67,6 +67,34 @@
   <Suppression>
     <DiagnosticId>CP0003</DiagnosticId>
     <Target>Qowaiv.Validation.Fluent, Version=2.0.0.0, Culture=neutral, PublicKeyToken=0e6640b5f269a3fc</Target>
+    <Left>lib/net9.0/Qowaiv.Validation.Fluent.dll</Left>
+    <Right>lib/net8.0/Qowaiv.Validation.Fluent.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0014</DiagnosticId>
+    <Target>T:Qowaiv.Validation.Fluent.ModelValidator`1&lt;0&gt;:[T:System.Runtime.CompilerServices.NullableAttribute]</Target>
+    <Left>lib/net8.0/Qowaiv.Validation.Fluent.dll</Left>
+    <Right>lib/net8.0/Qowaiv.Validation.Fluent.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0014</DiagnosticId>
+    <Target>T:Qowaiv.Validation.Fluent.ModelValidator`1&lt;0&gt;:[T:System.Runtime.CompilerServices.NullableAttribute]</Target>
+    <Left>lib/net9.0/Qowaiv.Validation.Fluent.dll</Left>
+    <Right>lib/net8.0/Qowaiv.Validation.Fluent.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0021</DiagnosticId>
+    <Target>T:Qowaiv.Validation.Fluent.ModelValidator`1``0:notnull</Target>
+    <Left>lib/net8.0/Qowaiv.Validation.Fluent.dll</Left>
+    <Right>lib/net8.0/Qowaiv.Validation.Fluent.dll</Right>
+    <IsBaselineSuppression>true</IsBaselineSuppression>
+  </Suppression>
+  <Suppression>
+    <DiagnosticId>CP0021</DiagnosticId>
+    <Target>T:Qowaiv.Validation.Fluent.ModelValidator`1``0:notnull</Target>
     <Left>lib/net9.0/Qowaiv.Validation.Fluent.dll</Left>
     <Right>lib/net8.0/Qowaiv.Validation.Fluent.dll</Right>
     <IsBaselineSuppression>true</IsBaselineSuppression>

--- a/src/Qowaiv.Validation.Fluent/ModelValidator.cs
+++ b/src/Qowaiv.Validation.Fluent/ModelValidator.cs
@@ -5,6 +5,7 @@ namespace Qowaiv.Validation.Fluent;
 /// The model to validate for.
 /// </typeparam>
 public class ModelValidator<TModel> : AbstractValidator<TModel>, Abstractions.IValidator<TModel>
+    where TModel : notnull
 {
     /// <summary>Initializes a new instance of the <see cref="ModelValidator{TModel}"/> class.</summary>
     protected ModelValidator() { }

--- a/src/Qowaiv.Validation.Fluent/Qowaiv.Validation.Fluent.csproj
+++ b/src/Qowaiv.Validation.Fluent/Qowaiv.Validation.Fluent.csproj
@@ -9,13 +9,13 @@
     <PackageId>Qowaiv.Validation.Fluent</PackageId>
     <ToBeReleased>
       <![CDATA[
-v3.*
--?
-    ]]>
+v3.1.0
+- Add notnull constraint to Result.For<T>().
+]]>
     </ToBeReleased>
     <PackageReleaseNotes>
       <![CDATA[
-v3.0.
+v3.0.0
 - `Before`, `After`, `NotBefore`, and `NotAfter` available for `IComparable`.
 - Update to Qowaiv v7.4.7.
 - Add .NET 10.0 target.

--- a/src/Qowaiv.Validation.Guarding/CompatibilitySuppressions.xml
+++ b/src/Qowaiv.Validation.Guarding/CompatibilitySuppressions.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Suppression>

--- a/src/Qowaiv.Validation.Messages/CompatibilitySuppressions.xml
+++ b/src/Qowaiv.Validation.Messages/CompatibilitySuppressions.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Suppression>

--- a/src/Qowaiv.Validation.TestTools/CompatibilitySuppressions.xml
+++ b/src/Qowaiv.Validation.TestTools/CompatibilitySuppressions.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Suppression>

--- a/src/Qowaiv.Validation.TestTools/Qowaiv.Validation.TestTools.csproj
+++ b/src/Qowaiv.Validation.TestTools/Qowaiv.Validation.TestTools.csproj
@@ -7,6 +7,12 @@
     <PackageValidationBaselineVersion>2.0.0</PackageValidationBaselineVersion>
     <Version>3.0.0</Version>
     <PackageId>Qowaiv.Validation.TestTools</PackageId>
+    <ToBeReleased>
+      <![CDATA[
+v3.*
+- 
+]]>
+    </ToBeReleased>
     <PackageReleaseNotes>
 <![CDATA[
 v3.0.0

--- a/src/Qowaiv.Validation.TestTools/WrapperValidator.cs
+++ b/src/Qowaiv.Validation.TestTools/WrapperValidator.cs
@@ -2,6 +2,7 @@ namespace Qowaiv.Validation.TestTools;
 
 /// <summary>Implements <see cref="IValidator{TModel}"/> using <see cref="FluentValidation.IValidator{T}"/>.</summary>
 internal sealed class WrapperValidator<TModel>(FluentValidation.IValidator<TModel> validator) : IValidator<TModel>
+    where TModel : notnull
 {
     private readonly FluentValidation.IValidator<TModel> _validator = validator;
 

--- a/src/Qowaiv.Validation.Xml/CompatibilitySuppressions.xml
+++ b/src/Qowaiv.Validation.Xml/CompatibilitySuppressions.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- https://learn.microsoft.com/dotnet/fundamentals/package-validation/diagnostic-ids -->
 <Suppressions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Suppression>


### PR DESCRIPTION
The `notnull` constraint on generic types helps write better code. It is added to `Result.For<T>` and all validators.